### PR TITLE
Add JSON file output option

### DIFF
--- a/src/nomad_actions/actions/entries/models.py
+++ b/src/nomad_actions/actions/entries/models.py
@@ -5,7 +5,7 @@ from nomad.app.v1.models.models import MetadataPagination, MetadataRequired, Que
 from pydantic import BaseModel, Field
 
 OwnerLiteral = Literal['public', 'visible', 'shared', 'user', 'staging']
-OutputFileTypeLiteral = Literal['parquet', 'csv']
+OutputFileTypeLiteral = Literal['parquet', 'csv', 'json']
 IndexLiteral = Literal['entries', 'datasets', 'models', 'spaces']
 
 

--- a/src/nomad_actions/actions/entries/utils.py
+++ b/src/nomad_actions/actions/entries/utils.py
@@ -44,8 +44,24 @@ def write_csv_file(path: str, data: list[dict]):
     df.to_csv(path, index=False, mode='w', header=True)
 
 
+def write_json_file(path: str, data: list[dict]):
+    """Writes a list of NOMAD entry dicts to a JSON file.
+
+    Args:
+        path (str): The path where the file will be saved.
+        data (list[dict]): The list of NOMAD entry dicts to be written to the file.
+    """
+    if not path.endswith('json'):
+        raise ValueError('Unsupported file type. Please use JSON.')
+
+    import json
+
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=4)
+
+
 def consolidate_files(input_file_paths: list[str], output_file_path: str):
-    """Consolidates multiple Parquet or CSV files into a single file.
+    """Consolidates multiple Parquet, CSV, or JSON files into a single file.
 
     Args:
         input_file_paths (list[str]): List of file paths to be consolidated.
@@ -78,5 +94,16 @@ def consolidate_files(input_file_paths: list[str], output_file_path: str):
             dataframes.append(df)
         combined_df = pd.concat(dataframes, ignore_index=True)
         combined_df.to_csv(output_file_path, index=False)
+    elif output_file_path.endswith('json'):
+        import json
+
+        combined_data = []
+        for file_path in input_file_paths:
+            with open(file_path, encoding='utf-8') as f:
+                data = json.load(f)
+                # extend the combined entry list with entry list from each file
+                combined_data.extend(data)
+        with open(output_file_path, 'w', encoding='utf-8') as f:
+            json.dump(combined_data, f, indent=4)
     else:
-        raise ValueError('Unsupported file type. Please use parquet or CSV.')
+        raise ValueError('Unsupported file type. Please use parquet, CSV, or JSON.')


### PR DESCRIPTION
This pull request adds support for generating JSON files in the export workflow, alongside the existing Parquet and CSV formats. The changes update type definitions, file writing utilities, and consolidation logic to recognize and process JSON files throughout the system.

**Support for JSON file format:**

* Updated `OutputFileTypeLiteral` in `models.py` to include `'json'` as a valid output file type.
* Added a new `write_json_file` utility function in `utils.py` to write NOMAD entry dictionaries to a JSON file, with validation for file extension.
* Modified the `search` activity in `activities.py` to support JSON as an output format, including relevant error handling and selection of the correct write function. [[1]](diffhunk://#diff-a58d60c3bce8f55302b2582e7a93115d9efa108f48a7de5b8dd7cad0072f8b15L40-R40) [[2]](diffhunk://#diff-a58d60c3bce8f55302b2582e7a93115d9efa108f48a7de5b8dd7cad0072f8b15L49-R72)

**Consolidation logic enhancements:**

* Updated the `consolidate_files` utility in `utils.py` to allow merging multiple JSON files, in addition to Parquet and CSV, into a single consolidated file.
* Updated documentation and error messages in both the `search` and `consolidate_output_files` activities to reflect support for JSON files. [[1]](diffhunk://#diff-a58d60c3bce8f55302b2582e7a93115d9efa108f48a7de5b8dd7cad0072f8b15L114-R120) [[2]](diffhunk://#diff-e7e06e1c0e7ebac6a12a073b1d1bbc46f12322ecfc61cd7bc64b46c001135d3fR47-R64)

These changes ensure that the workflow can now seamlessly handle JSON files for both output and consolidation tasks.