### PR TITLE
Use Parquet batches for CSV output

### DIFF
--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -118,7 +118,7 @@ async def merge_output_files(data: MergeOutputFilesInput) -> str | None:
         raise ValueError('No generated file paths provided for merging.')
 
     merged_file_path = os.path.join(
-        data.artifact_subdirectory, 'data.' + data.batch_file_type
+        data.artifact_subdirectory, 'data.' + data.output_file_type
     )
 
     merge_files(data.generated_file_paths, data.output_file_type, merged_file_path)

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -19,7 +19,6 @@ from nomad_ml_workflows.actions.export_entries.models import (
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
     merge_files,
-    write_csv_file,
     write_json_file,
     write_parquet_file,
 )

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -52,7 +52,7 @@ async def create_artifact_subdirectory(data: CreateArtifactSubdirectoryInput) ->
 async def search(data: SearchInput) -> SearchOutput:
     """
     Activity to perform NOMAD search based on the provided input data. The search
-    results are written to a file in the specified format (Parquet, CSV, or JSON) in the
+    results are written to a file in the specified format (Parquet or JSON) in the
     artifacts directory.
 
     Args:
@@ -64,14 +64,10 @@ async def search(data: SearchInput) -> SearchOutput:
 
     write_dataset_file = {
         'parquet': write_parquet_file,
-        'csv': write_csv_file,
         'json': write_json_file,
-    }.get(data.output_file_type)
+    }.get(data.batch_file_type)
     if write_dataset_file is None:
-        raise ValueError(
-            f'Unsupported file type "{data.output_file_type}". '
-            'Please use parquet, csv, or json as file types.'
-        )
+        raise ValueError(f'Unsupported batch file type "{data.batch_file_type}". ')
 
     start = datetime.now(timezone.utc).isoformat()
     response = nomad_search(
@@ -110,7 +106,7 @@ async def search(data: SearchInput) -> SearchOutput:
 @activity.defn
 async def merge_output_files(data: MergeOutputFilesInput) -> str | None:
     """
-    Activity to merge multiple Parquet, CSV, or JSON files into a single file.
+    Activity to merge multiple batch files into a single file.
 
     Args:
         data (MergeOutputFilesInput): Input data for merging files.
@@ -123,7 +119,7 @@ async def merge_output_files(data: MergeOutputFilesInput) -> str | None:
         raise ValueError('No generated file paths provided for merging.')
 
     merged_file_path = os.path.join(
-        data.artifact_subdirectory, 'merged.' + data.output_file_type
+        data.artifact_subdirectory, 'data.' + data.batch_file_type
     )
 
     merge_files(data.generated_file_paths, data.output_file_type, merged_file_path)

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -5,6 +5,7 @@ from nomad.app.v1.models.models import MetadataPagination, MetadataRequired, Que
 from pydantic import BaseModel, Field
 
 OwnerLiteral = Literal['public', 'visible', 'shared', 'user', 'staging']
+BatchFileTypeLiteral = Literal['parquet', 'json']
 OutputFileTypeLiteral = Literal['parquet', 'csv', 'json']
 IndexLiteral = Literal['entries', 'datasets', 'models', 'spaces']
 
@@ -80,7 +81,7 @@ class SearchInput(BaseModel):
     pagination: MetadataPagination = Field(
         ..., description='Pagination settings for the search results.'
     )
-    output_file_type: OutputFileTypeLiteral = Field(
+    batch_file_type: BatchFileTypeLiteral = Field(
         ..., description='Type of the output file.'
     )
     output_file_path: str = Field(..., description='Path to the generated output file.')
@@ -124,13 +125,17 @@ class SearchInput(BaseModel):
 
         pagination = MetadataPagination(page_size=user_input.output_settings.batch_size)
 
+        batch_file_type = user_input.output_settings.output_file_type
+        if batch_file_type == 'csv':
+            batch_file_type = 'parquet'  # use parquet batches for csv
+
         return cls(
             user_id=user_input.user_id,
             owner=user_input.search_settings.owner,
             query=query,
             required=required,
             pagination=pagination,
-            output_file_type=user_input.output_settings.output_file_type,
+            batch_file_type=batch_file_type,
             output_file_path=output_file_path,
             max_entries_export_limit=max_entries_export_limit,
         )

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -68,7 +68,7 @@ def write_json_file(path: str, data: list[dict]):
 def merge_files(
     input_file_paths: list[str], output_file_type: str, output_file_path: str
 ):
-    """Merges multiple Parquet, CSV, or JSON files into a single file.
+    """Merges multiple Parquet or JSON files into a single file.
 
     Args:
         input_file_paths (list[str]): List of file paths to be merged.
@@ -93,28 +93,11 @@ def merge_files(
                 writer.write_batch(batch)
 
     elif output_file_type == 'csv':
-        # Additional timestamp parser for ISO with microseconds and timezone with colon
-        # (e.g., 2023-10-05T14:48:00.000000+00:00)
-        # This is used in NOMAD `nomad.metainfo.metainfo.Datetime` serialization
-        convert_options = pcsv.ConvertOptions(
-            timestamp_parsers=[
-                '%Y-%m-%dT%H:%M:%S.%f%z',
-            ]
-        )
-        # Read more rows for schema inference to avoid null type inference errors
-        # CAUTION: this might not scale for very large files
-        read_options = pcsv.ReadOptions(
-            block_size=100 << 20,  # 100 MB blocks for better schema inference
-        )
-        # Creates a logical dataset from the input CSV files, not loading all data into
+        # Creates a logical dataset from the input files, not loading all data into
         # memory. Also, unifies the schema across the files.
-        dataset = ds.dataset(
-            input_file_paths,
-            format=ds.CsvFileFormat(
-                convert_options=convert_options,
-                read_options=read_options,
-            ),
-        )
+        # The batch files for `csv` are written in Parquet format for efficiency,
+        # so we read them as Parquet here.
+        dataset = ds.dataset(input_file_paths, format='parquet')
 
         # Write the dataset to a single CSV file in batches
         with pa.csv.CSVWriter(output_file_path, dataset.schema) as writer:

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -80,8 +80,8 @@ class ExportEntriesWorkflow:
             while True:
                 search_counter += 1
                 search_input.output_file_path = (
-                    f'{artifact_subdirectory}/'
-                    f'{search_counter}.{data.output_settings.output_file_type}'
+                    f'{artifact_subdirectory}/{search_counter}.'
+                    f'{search_input.batch_file_type}'
                 )
                 search_output = await workflow.execute_activity(
                     search,


### PR DESCRIPTION
- When selecting CSV as the output file type for the workflow, the intermediate batch files will be Parquet files instead of batch CSVs. This improves the accuracy of the logical dataset schema when merging the batch files.

- The columns with nested data types (list of string for example) are converted into strings when creating a single big CSV file during the merging activity.

- Resolves https://github.com/FAIRmat-NFDI/nomad-ml-workflows/issues/31#issuecomment-3811331995