### PR TITLE
Refactor Export Entries form

### DIFF
--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -27,7 +27,7 @@ class SearchSettings(BaseModel):
         {
             'entry_type': 'ELNSample'
         }""",
-        # TODO: add `ui:widget` though `json_schema_extra` after NOMAD UI supports it
+        json_schema_extra={'ui:widget': 'textarea', 'ui:options': {'rows': 5}},
     )
     required_include: list[str] = Field(
         [],

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -14,6 +14,12 @@ class SearchSettings(BaseModel):
     owner: OwnerLiteral = Field(
         'visible', description='Owner of the entries to be searched.'
     )
+    page_size: int = Field(
+        1000,
+        gt=0,
+        description='Number of entries to be fetched and written per search page. '
+        'Use smaller page sizes when exporting large entries to reduce memory usage.',
+    )
     query: str = Field(
         ...,
         description="""Query for extracting entries. Should be a valid dictionary
@@ -39,12 +45,6 @@ class OutputSettings(BaseModel):
     output_file_type: OutputFileTypeLiteral = Field(
         'parquet',
         description='Type of the output file.',
-    )
-    batch_size: int = Field(
-        1000,
-        gt=0,
-        description='Number of entries to be fetched and written per search batch. '
-        'Use smaller batch sizes when exporting large entries to reduce memory usage.',
     )
     zip_output: bool = Field(
         True,
@@ -123,7 +123,7 @@ class SearchInput(BaseModel):
             ]
             required.exclude = exclude if exclude else None
 
-        pagination = MetadataPagination(page_size=user_input.output_settings.batch_size)
+        pagination = MetadataPagination(page_size=user_input.search_settings.page_size)
 
         batch_file_type = user_input.output_settings.output_file_type
         if batch_file_type == 'csv':

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -24,12 +24,12 @@ class SearchSettings(BaseModel):
         # TODO: add `ui:widget` though `json_schema_extra` after NOMAD UI supports it
     )
     required_include: list[str] = Field(
-        None,
+        [],
         description='List of fields to include in the search results. For example: '
         'results*, data.results*',
     )
     required_exclude: list[str] = Field(
-        None,
+        [],
         description='List of fields to exclude from the search results. For example: '
         'results.method.method_name',
     )
@@ -110,7 +110,7 @@ class SearchInput(BaseModel):
         )
 
         required = MetadataRequired()
-        if user_input.search_settings.required_include is not None:
+        if user_input.search_settings.required_include:
             include = [
                 _clean_field(field)
                 for field in user_input.search_settings.required_include


### PR DESCRIPTION
- RJSF used in `nomad-gui` leads to errors that the `required_include` and `required_exclude` fields should be filled even though they can be None as per datamodel. Switching the default to `[]` instead of `None` fixes this.
- Use `json_schema_extra` to supply in `uiSchema` for RJSF in `query` field. Currently, it might not be supported in the gui. At a later time, this will be used for rendering forms.
- Move `OutputSettings.batch_size` to `SearchSettings.page_size` for sake of clarity. "Batch size" is now only used for setting the page size anyways.