### PR TITLE
Parallelise searching pages

### DIFF
--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -7,6 +7,12 @@ with workflow.unsafe.imports_passed_through():
 
 
 class ExportEntriesActionEntryPoint(ActionEntryPoint):
+    search_workflow_concurrency_limit: int = Field(
+        default=5,
+        description='Number of child search workflow instances to run concurrently in '
+        'the Export Entries action. Keep this low to avoid overwhelming the Temporal '
+        'server with too many concurrent activities.',
+    )
     search_batch_timeout: int = Field(
         default=7200,  # 2 hours
         description='Timeout (in seconds) for each search batch in the Export Entries '

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -23,6 +23,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
 
         from nomad_ml_workflows.actions.export_entries.activities import (
             cleanup_artifacts,
+            collect_page_cursors,
             create_artifact_subdirectory,
             export_dataset_to_upload,
             merge_output_files,
@@ -39,6 +40,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
             child_workflows=[SearchPageWorkflow],
             activities=[
                 create_artifact_subdirectory,
+                collect_page_cursors,
                 search,
                 merge_output_files,
                 export_dataset_to_upload,

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -30,11 +30,13 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
         )
         from nomad_ml_workflows.actions.export_entries.workflows import (
             ExportEntriesWorkflow,
+            SearchPageWorkflow,
         )
 
         return Action(
             task_queue=self.task_queue,
             workflow=ExportEntriesWorkflow,
+            child_workflows=[SearchPageWorkflow],
             activities=[
                 create_artifact_subdirectory,
                 search,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -3,14 +3,18 @@ import os
 import shutil
 import zipfile
 from datetime import datetime, timezone
+from math import ceil
 
 from nomad.actions.manager import action_artifacts_dir, get_upload_files
+from nomad.app.v1.models.models import MetadataPagination, MetadataRequired
 from nomad.files import StagingUploadFiles
 from nomad.search import search as nomad_search
 from temporalio import activity
 
 from nomad_ml_workflows.actions.export_entries.models import (
     CleanupArtifactsInput,
+    CollectCursorsInput,
+    CollectCursorsOutput,
     CreateArtifactSubdirectoryInput,
     ExportDatasetInput,
     MergeOutputFilesInput,
@@ -100,6 +104,73 @@ async def search(data: SearchInput) -> SearchOutput:
         write_dataset_file(path=data.output_file_path, data=entry_list)
 
     return output
+
+
+@activity.defn
+async def collect_page_cursors(data: CollectCursorsInput) -> CollectCursorsOutput:
+    """
+    Activity to serially walk NOMAD search pagination and collect all
+    page_after_value cursors needed for parallel page fetching.
+
+    Only entry IDs are requested to minimise payload size.
+
+    Assumption: The cursors are valid for any subsequent search with the same query,
+    regardless of the required fields used in those searches.
+
+    Args:
+        data (CollectCursorsInput): Input data specifying the search and limits.
+
+    Returns:
+        CollectCursorsOutput: All page cursors and the total entry count.
+    """
+
+    # Use minimal required fields so the probe searches are as fast as possible.
+    required = MetadataRequired(include=['entry_id'])
+
+    # First page: cursor is None (start of results).
+    pagination = MetadataPagination(page_size=data.page_size)
+    response = nomad_search(
+        user_id=data.user_id,
+        owner=data.owner,
+        query=data.query,
+        required=required,
+        pagination=pagination,
+        aggregations={},
+    )
+
+    # determine the number of pages needed, incl. the first page
+    num_entries_available = response.pagination.total
+    num_entries_to_export = min(num_entries_available, data.max_entries_export_limit)
+    num_pages = (
+        ceil(num_entries_to_export / data.page_size) if num_entries_to_export > 0 else 0
+    )
+
+    page_after_values: list[str | None] = []
+    if num_pages > 0:
+        page_after_values.append(None)  # first page always starts at the beginning
+
+    cursor = response.pagination.next_page_after_value
+    for _ in range(num_pages - 1):
+        if cursor is None:
+            break
+        page_after_values.append(cursor)
+        pagination = MetadataPagination(
+            page_size=data.page_size, page_after_value=cursor
+        )
+        response = nomad_search(
+            user_id=data.user_id,
+            owner=data.owner,
+            query=data.query,
+            required=required,
+            pagination=pagination,
+            aggregations={},
+        )
+        cursor = response.pagination.next_page_after_value
+
+    return CollectCursorsOutput(
+        page_after_values=page_after_values,
+        num_entries_available=num_entries_available,
+    )
 
 
 @activity.defn

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -152,10 +152,10 @@ class SearchOutput(BaseModel):
         description='Total number of entries available for the given search query.',
     )
     search_start_time: str = Field(
-        ..., description='Timestamp when the search started.'
+        ..., description='UTC Timestamp (ISO) when the search started.'
     )
     search_end_time: str = Field(
-        ..., description='Timestamp when the search completed.'
+        ..., description='UTC Timestamp (ISO) when the search completed.'
     )
     pagination_next_page_after_value: str | None = Field(
         None,
@@ -178,7 +178,8 @@ class CollectCursorsOutput(BaseModel):
     page_after_values: list[str | None] = Field(
         ...,
         description='List of page_after_value cursors, one per page. '
-        'The first entry is always None (start of first page).',
+        'The first entry is None (start of first page) when at least one page is '
+        'available. If num_entries_available is 0, it is an empty list.',
     )
     num_entries_available: int = Field(
         ...,
@@ -219,11 +220,11 @@ class ExportDatasetMetadata(BaseModel):
     )
     search_start_time: str = Field(
         '',
-        description='Timestamp when the first search batch started.',
+        description='UTC Timestamp (ISO) when the first search batch started.',
     )
     search_end_time: str = Field(
         '',
-        description='Timestamp when the last search batch completed.',
+        description='UTC Timestamp (ISO) when the last search batch completed.',
     )
     user_input: ExportEntriesUserInput | None = Field(
         None, description='Original user input for the export entries workflow.'

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -164,6 +164,28 @@ class SearchOutput(BaseModel):
     )
 
 
+class CollectCursorsInput(BaseModel):
+    user_id: str = Field(..., description='User ID performing the search.')
+    owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
+    query: Query = Field(..., description='Search query parameters.')
+    page_size: int = Field(..., description='Number of entries per page.')
+    max_entries_export_limit: int = Field(
+        ..., description='Maximum number of entries to be exported.'
+    )
+
+
+class CollectCursorsOutput(BaseModel):
+    page_after_values: list[str | None] = Field(
+        ...,
+        description='List of page_after_value cursors, one per page. '
+        'The first entry is always None (start of first page).',
+    )
+    num_entries_available: int = Field(
+        ...,
+        description='Total number of entries available for the given search query.',
+    )
+
+
 class MergeOutputFilesInput(BaseModel):
     artifact_subdirectory: str = Field(
         ...,

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import timedelta
 
 from temporalio import workflow
@@ -66,6 +67,11 @@ class ExportEntriesWorkflow:
         Workflow to search entries and export them into a datafile in the specified
         upload.
 
+        All search pages are fetched in parallel using child workflows. A lightweight
+        cursor-collection activity first walks the pagination to determine the
+        page_after_value for every page, then one SearchPageWorkflow child workflow
+        is launched per page and all are awaited concurrently.
+
         Args:
             data (ExportEntriesUserInput): Input data for the export entries workflow.
         Returns:
@@ -107,7 +113,7 @@ class ExportEntriesWorkflow:
             )
             page_size = data.search_settings.page_size
 
-            # -collect all page cursors with a lightweight serial walk ---
+            # Collect all page cursors with a lightweight serial walk
             cursors_output = await workflow.execute_activity(
                 collect_page_cursors,
                 CollectCursorsInput(
@@ -126,7 +132,7 @@ class ExportEntriesWorkflow:
                 num_entries_available > config.max_entries_export_limit
             )
 
-            # build one SearchInput per page with the corresponding cursor and
+            # Build one SearchInput per page with the corresponding cursor and
             # export limit for that page
             search_inputs: list[SearchInput] = []
             for page_index, cursor in enumerate(cursors_output.page_after_values):
@@ -149,6 +155,31 @@ class ExportEntriesWorkflow:
                 )
                 search_inputs.append(si)
 
+            # Run search for all pages in parallel as child workflows
+            search_results = await asyncio.gather(
+                *[
+                    workflow.execute_child_workflow(
+                        SearchPageWorkflow.run,
+                        si,
+                        id=f'{workflow.info().workflow_id}-search-page-{i + 1}',
+                    )
+                    for i, si in enumerate(search_inputs)
+                ]
+            )
+
+            # Collect outputs preserving page order
+            generated_file_paths = [
+                search_inputs[i].output_file_path
+                for i, result in enumerate(search_results)
+                if result.num_entries_exported > 0
+            ]
+            total_num_entries_exported = sum(
+                result.num_entries_exported for result in search_results
+            )
+            search_start_times = [result.search_start_time for result in search_results]
+            search_end_times = [result.search_end_time for result in search_results]
+
+            # Merge batch files into one file to be exported
             merged_file_path = await workflow.execute_activity(
                 merge_output_files,
                 MergeOutputFilesInput(
@@ -161,16 +192,19 @@ class ExportEntriesWorkflow:
             )
 
             # Prepare export dataset input and metadata
+            # Pages ran in parallel so take the earliest start and latest end.
+            earliest_start = min(search_start_times)
+            latest_end = max(search_end_times)
             export_dataset_input.exportable_dir_name = (
-                'export_entries_' + search_start_times[0].replace(':', '-')
+                'export_entries_' + earliest_start.replace(':', '-')
             )
             export_dataset_input.source_paths = [merged_file_path]
             export_dataset_input.metadata = ExportDatasetMetadata(
                 num_entries_exported=total_num_entries_exported,
                 num_entries_available=num_entries_available,
                 reached_max_entries_limit=reached_max_entries_limit,
-                search_start_time=search_start_times[0],
-                search_end_time=search_end_times[-1],
+                search_start_time=earliest_start,
+                search_end_time=latest_end,
                 user_input=data,
             )
 

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -83,7 +83,9 @@ class ExportEntriesWorkflow:
             user_id=data.user_id,
             upload_id=data.upload_id,
             artifact_subdirectory=artifact_subdirectory,
-            exportable_dir_name='export_entries_error',  # name used in case of error
+            exportable_dir_name=(
+                f'export_entries_{workflow.info().start_time.isoformat()}'
+            ),
             zip_output=data.output_settings.zip_output,
             source_paths=[],
             metadata=ExportDatasetMetadata(user_input=data),
@@ -187,9 +189,7 @@ class ExportEntriesWorkflow:
             # Pages ran in parallel so take the earliest start and latest end.
             earliest_start = min(search_start_times)
             latest_end = max(search_end_times)
-            export_dataset_input.exportable_dir_name = (
-                'export_entries_' + earliest_start.replace(':', '-')
-            )
+
             export_dataset_input.source_paths = [merged_file_path]
             export_dataset_input.metadata = ExportDatasetMetadata(
                 num_entries_exported=total_num_entries_exported,

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -45,12 +45,7 @@ class SearchPageWorkflow:
         config = nomad_config.get_plugin_entry_point(
             'nomad_ml_workflows.actions:export_entries'
         )
-        retry_policy = RetryPolicy(
-            maximum_attempts=1,
-            initial_interval=timedelta(seconds=10),
-            maximum_interval=timedelta(minutes=1),
-            backoff_coefficient=2.0,
-        )
+        retry_policy = RetryPolicy(maximum_attempts=1)
         return await workflow.execute_activity(
             search,
             data,
@@ -77,12 +72,7 @@ class ExportEntriesWorkflow:
         Returns:
             str: Path to the saved dataset in the upload's `raw` folder.
         """
-        retry_policy = RetryPolicy(
-            maximum_attempts=1,
-            initial_interval=timedelta(seconds=10),
-            maximum_interval=timedelta(minutes=1),
-            backoff_coefficient=2.0,
-        )
+        retry_policy = RetryPolicy(maximum_attempts=1)
         artifact_subdirectory = await workflow.execute_activity(
             create_artifact_subdirectory,
             CreateArtifactSubdirectoryInput(subdir_name=workflow.info().workflow_id),
@@ -162,6 +152,8 @@ class ExportEntriesWorkflow:
                         SearchPageWorkflow.run,
                         si,
                         id=f'{workflow.info().workflow_id}-search-page-{i + 1}',
+                        parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
+                        retry_policy=retry_policy,
                     )
                     for i, si in enumerate(search_inputs)
                 ]

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -5,10 +5,12 @@ from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
 
 with workflow.unsafe.imports_passed_through():
+    from nomad.app.v1.models.models import MetadataPagination
     from nomad.config import config as nomad_config
 
     from nomad_ml_workflows.actions.export_entries.activities import (
         cleanup_artifacts,
+        collect_page_cursors,
         create_artifact_subdirectory,
         export_dataset_to_upload,
         merge_output_files,
@@ -16,6 +18,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from nomad_ml_workflows.actions.export_entries.models import (
         CleanupArtifactsInput,
+        CollectCursorsInput,
         CreateArtifactSubdirectoryInput,
         ExportDatasetInput,
         ExportDatasetMetadata,
@@ -95,57 +98,56 @@ class ExportEntriesWorkflow:
                 'nomad_ml_workflows.actions:export_entries'
             )
 
-            search_counter = 0
-            num_entries_available = 0
-            generated_file_paths = []
-            search_start_times = []
-            search_end_times = []
-            total_num_entries_exported = 0
-            reached_max_entries_limit = False
-            search_input = SearchInput.from_user_input(
+            # Build a representative SearchInput to resolve shared settings
+            # (query, owner, required, batch_file_type) once.
+            template_search_input = SearchInput.from_user_input(
                 data,
-                output_file_path='',  # Placeholder, will be set in loop
+                output_file_path='',  # placeholder, real paths are set per page below
                 max_entries_export_limit=config.max_entries_export_limit,
             )
-            while True:
-                search_counter += 1
-                search_input.output_file_path = (
-                    f'{artifact_subdirectory}/{search_counter}.'
-                    f'{search_input.batch_file_type}'
-                )
-                search_output = await workflow.execute_activity(
-                    search,
-                    search_input,
-                    activity_id=f'search-activity-{search_counter}',
-                    start_to_close_timeout=timedelta(
-                        seconds=config.search_batch_timeout
-                    ),
-                    retry_policy=retry_policy,
-                )
-                if search_counter == 1:
-                    # capture the total available entries from the first search output
-                    num_entries_available = search_output.num_entries_available
-                if search_output.num_entries_exported > 0:
-                    # only save paths if the writing files was not skipped
-                    generated_file_paths.append(search_input.output_file_path)
-                search_start_times.append(search_output.search_start_time)
-                search_end_times.append(search_output.search_end_time)
-                total_num_entries_exported += search_output.num_entries_exported
-                # Update pagination for next iteration
-                search_input.pagination.page_after_value = (
-                    search_output.pagination_next_page_after_value
-                )
-                search_input.max_entries_export_limit -= (
-                    search_output.num_entries_exported
-                )
+            page_size = data.search_settings.page_size
 
-                if search_output.pagination_next_page_after_value is None:
-                    # break if there are no more pages to fetch
-                    break
-                if search_input.max_entries_export_limit <= 0:
-                    # break early if the max entries limit has been reached
-                    reached_max_entries_limit = True
-                    break
+            # -collect all page cursors with a lightweight serial walk ---
+            cursors_output = await workflow.execute_activity(
+                collect_page_cursors,
+                CollectCursorsInput(
+                    user_id=data.user_id,
+                    owner=data.search_settings.owner,
+                    query=template_search_input.query,
+                    page_size=page_size,
+                    max_entries_export_limit=config.max_entries_export_limit,
+                ),
+                start_to_close_timeout=timedelta(hours=2),
+                retry_policy=retry_policy,
+            )
+
+            num_entries_available = cursors_output.num_entries_available
+            reached_max_entries_limit = (
+                num_entries_available > config.max_entries_export_limit
+            )
+
+            # build one SearchInput per page with the corresponding cursor and
+            # export limit for that page
+            search_inputs: list[SearchInput] = []
+            for page_index, cursor in enumerate(cursors_output.page_after_values):
+                entries_so_far = page_index * page_size
+                limit_for_page = min(
+                    page_size, config.max_entries_export_limit - entries_so_far
+                )
+                si = template_search_input.model_copy(
+                    update={
+                        'output_file_path': (
+                            f'{artifact_subdirectory}/{page_index + 1}'
+                            f'.{template_search_input.batch_file_type}'
+                        ),
+                        'max_entries_export_limit': limit_for_page,
+                        'pagination': MetadataPagination(
+                            page_size=page_size,
+                            page_after_value=cursor,
+                        ),
+                    }
+                )
+                search_inputs.append(si)
 
             merged_file_path = await workflow.execute_activity(
                 merge_output_files,

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -22,7 +22,37 @@ with workflow.unsafe.imports_passed_through():
         ExportEntriesUserInput,
         MergeOutputFilesInput,
         SearchInput,
+        SearchOutput,
     )
+
+
+@workflow.defn
+class SearchPageWorkflow:
+    """
+    Child workflow that executes a single search page activity.
+
+    Each instance handles one page of results, identified by its
+    page_after_value cursor. Running multiple instances concurrently
+    via the parent workflow achieves parallel page fetching.
+    """
+
+    @workflow.run
+    async def run(self, data: SearchInput) -> SearchOutput:
+        config = nomad_config.get_plugin_entry_point(
+            'nomad_ml_workflows.actions:export_entries'
+        )
+        retry_policy = RetryPolicy(
+            maximum_attempts=1,
+            initial_interval=timedelta(seconds=10),
+            maximum_interval=timedelta(minutes=1),
+            backoff_coefficient=2.0,
+        )
+        return await workflow.execute_activity(
+            search,
+            data,
+            start_to_close_timeout=timedelta(seconds=config.search_batch_timeout),
+            retry_policy=retry_policy,
+        )
 
 
 @workflow.defn

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -188,8 +188,8 @@ class ExportEntriesWorkflow:
                 retry_policy=retry_policy,
             )
 
-            # Prepare export dataset input and metadata
-            # Pages ran in parallel so take the earliest start and latest end.
+            # Pages ran in parallel so take the earliest start and latest end. ISO
+            # timestamp strings can be compared lexicographically
             earliest_start = min(search_start_times)
             latest_end = max(search_end_times)
 

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -150,19 +150,30 @@ class ExportEntriesWorkflow:
                 )
                 search_inputs.append(si)
 
-            # Run search for all pages in parallel as child workflows
-            search_results = await asyncio.gather(
-                *[
-                    workflow.execute_child_workflow(
-                        SearchPageWorkflow.run,
-                        si,
-                        id=f'{workflow.info().workflow_id}-search-page-{i + 1}',
-                        parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
-                        retry_policy=retry_policy,
-                    )
-                    for i, si in enumerate(search_inputs)
+            # Run child workflows for each page with bounded concurrency to avoid
+            # overwhelming the Temporal server with too many concurrent searches.
+            search_results = []
+            for concurr_batch_start in range(
+                0, len(search_inputs), config.search_workflow_concurrency_limit
+            ):
+                concurr_batch_search_inputs = search_inputs[
+                    concurr_batch_start : concurr_batch_start
+                    + config.search_workflow_concurrency_limit
                 ]
-            )
+                concurr_batch_results = await asyncio.gather(
+                    *[
+                        workflow.execute_child_workflow(
+                            SearchPageWorkflow.run,
+                            si,
+                            id=f'{workflow.info().workflow_id}-search-page-'
+                            f'{concurr_batch_start + i + 1}',
+                            parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
+                            retry_policy=retry_policy,
+                        )
+                        for i, si in enumerate(concurr_batch_search_inputs)
+                    ]
+                )
+                search_results.extend(concurr_batch_results)
 
             # Collect outputs preserving page order
             generated_file_paths = [
@@ -188,7 +199,7 @@ class ExportEntriesWorkflow:
                 retry_policy=retry_policy,
             )
 
-            # Pages ran in parallel so take the earliest start and latest end. ISO
+            # Pages ran concurrently so take the earliest start and latest end. ISO
             # timestamp strings can be compared lexicographically
             earliest_start = min(search_start_times)
             latest_end = max(search_end_times)

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -119,9 +119,12 @@ class ExportEntriesWorkflow:
                 retry_policy=retry_policy,
             )
 
-            num_entries_available = cursors_output.num_entries_available
+            if cursors_output.num_entries_available == 0:
+                # No entries to export, return early with an empty dataset
+                return
+
             reached_max_entries_limit = (
-                num_entries_available > config.max_entries_export_limit
+                cursors_output.num_entries_available > config.max_entries_export_limit
             )
 
             # Build one SearchInput per page with the corresponding cursor and
@@ -193,7 +196,7 @@ class ExportEntriesWorkflow:
             export_dataset_input.source_paths = [merged_file_path]
             export_dataset_input.metadata = ExportDatasetMetadata(
                 num_entries_exported=total_num_entries_exported,
-                num_entries_available=num_entries_available,
+                num_entries_available=cursors_output.num_entries_available,
                 reached_max_entries_limit=reached_max_entries_limit,
                 search_start_time=earliest_start,
                 search_end_time=latest_end,


### PR DESCRIPTION
This PR introduces performance enhancing changes. Each search page is processed by a child workflow in a bounded concurrency fashion. This can achieve true parallelism if multiple workers are pooling `TaskQueue.CPU` queue.