### PR TITLE
Make activity compatible with new interface in nomad-lab>1.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab>=1.4.0",
+    "nomad-lab>=1.4.3",
     "json-stream",
     "pydantic",
     "temporalio",

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -248,7 +248,7 @@ async def export_dataset_to_upload(data: ExportDatasetInput) -> str:
                 arcname = os.path.basename(filepath)
                 zipf.write(filepath, arcname=arcname)
         # Add zip file to the NOMAD Upload
-        upload_files.add_rawfiles(path=zippath, auto_decompress=False)
+        upload_files.add_rawfiles(target_path=zippath, auto_decompress=False)
         return zipname
 
     # If not zipping, copy files to directory named exportable_dir_name
@@ -259,7 +259,7 @@ async def export_dataset_to_upload(data: ExportDatasetInput) -> str:
         shutil.copy2(filepath, temp_path)
         # Add directory to the NOMAD Upload
         upload_files.add_rawfiles(
-            path=exportable_dir_path, target_dir=exportable_dir_name
+            target_path=exportable_dir_path, target_dir=exportable_dir_name
         )
     return exportable_dir_name
 


### PR DESCRIPTION
Interface changes in `nomad.files.StagingUploadFiles.add_rawfiles` [here](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/2968).