### PR TITLE
Read data from archives

### DIFF
--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -33,6 +33,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
             create_artifact_subdirectory,
             export_dataset_to_upload,
             merge_output_files,
+            read_archives,
             search,
         )
         from nomad_ml_workflows.actions.export_entries.workflows import (
@@ -48,6 +49,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
                 create_artifact_subdirectory,
                 collect_page_cursors,
                 search,
+                read_archives,
                 merge_output_files,
                 export_dataset_to_upload,
                 cleanup_artifacts,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -18,8 +18,8 @@ from nomad_ml_workflows.actions.export_entries.models import (
     CreateArtifactSubdirectoryInput,
     ExportDatasetInput,
     MergeOutputFilesInput,
-    SearchInput,
-    SearchOutput,
+    SearchPageInput,
+    SearchPageOutput,
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
     merge_files,
@@ -52,11 +52,14 @@ async def create_artifact_subdirectory(data: CreateArtifactSubdirectoryInput) ->
 
 
 @activity.defn
-async def search(data: SearchInput) -> SearchOutput:
+async def search(data: SearchPageInput) -> SearchPageOutput:
     """
-    Activity to perform NOMAD search based on the provided input data. The search
-    results are written to a file in the specified format (Parquet or JSON) in the
-    artifacts directory.
+    Activity to perform NOMAD search based on the provided input data. The data indexed
+    in the ElasticSearch is read and written to a file in the specified format
+    (Parquet or JSON) in the artifacts directory.
+
+    No archives are read in this activity; non-indexed data like nd-arrays will not be
+    extrated.
 
     Args:
         data (SearchInput): Input data for the search activity.
@@ -89,7 +92,7 @@ async def search(data: SearchInput) -> SearchOutput:
     if entry_list:
         write_dataset_file(path=data.output_file_path, data=entry_list)
 
-    return SearchOutput(
+    return SearchPageOutput(
         search_start_time=start,
         search_end_time=end,
         num_entries_exported=len(entry_list),

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from math import ceil
 
 from nomad.actions.manager import action_artifacts_dir, get_upload_files
-from nomad.app.v1.models.models import MetadataPagination, MetadataRequired
+from nomad.app.v1.models.models import MetadataPagination, MetadataRequired, User
 from nomad.files import StagingUploadFiles
 from nomad.search import search as nomad_search
 from temporalio import activity
@@ -187,7 +187,6 @@ async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
     Returns:
         SearchPageOutput: Output data from the search and read archives activity.
     """
-    from nomad.app.v1.models import User
     from nomad.app.v1.routers.entries import _read_entry_from_archive, _Uploads
     from nomad.archive.required import RequiredReader
 

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -210,8 +210,12 @@ async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
     ]
     entries = entries[: data.max_entries_export_limit]  #  Apply max limit
 
-    # setup required reader and archives list
-    required_reader = RequiredReader(data.required, user=User(user_id=data.user_id))
+    # setup required reader
+    required_reader = RequiredReader(
+        data.required,
+        resolve_inplace=True,
+        user=User(user_id=data.user_id),
+    )
     entry_archives = []
 
     # For each entry

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -178,8 +178,8 @@ async def collect_page_cursors(data: CollectCursorsInput) -> CollectCursorsOutpu
 async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
     """
     Activity to read archives of the searched entries. The required fields are read
-    and written to a file in the specified format (Parquet or JSON) in the
-    artifacts directory.
+    from the archives and written to a file in the specified format (Parquet or JSON)
+    in the artifacts directory.
 
     Args:
         data (ReadArchivesInput): Input data for the search activity.
@@ -200,7 +200,6 @@ async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
         query=data.query,
         required=MetadataRequired(include=['entry_id', 'upload_id']),
         pagination=data.pagination,
-        aggregations={},  # aggregations support can be added later
     )
     entries: list = [
         {

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -18,6 +18,7 @@ from nomad_ml_workflows.actions.export_entries.models import (
     CreateArtifactSubdirectoryInput,
     ExportDatasetInput,
     MergeOutputFilesInput,
+    ReadArchivesInput,
     SearchPageInput,
     SearchPageOutput,
 )
@@ -170,6 +171,69 @@ async def collect_page_cursors(data: CollectCursorsInput) -> CollectCursorsOutpu
         page_after_values=page_after_values,
         num_entries_available=num_entries_available,
         num_pages=num_pages,
+    )
+
+
+@activity.defn
+async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
+    """
+    Activity to read archives of the searched entries. The required fields are read
+    and written to a file in the specified format (Parquet or JSON) in the
+    artifacts directory.
+
+    Args:
+        data (ReadArchivesInput): Input data for the search activity.
+
+    Returns:
+        SearchPageOutput: Output data from the search and read archives activity.
+    """
+    from nomad.app.v1.models import User
+    from nomad.app.v1.routers.entries import _read_entry_from_archive, _Uploads
+    from nomad.archive.required import RequiredReader
+
+    start = datetime.now(timezone.utc).isoformat()
+
+    # Find entries whose archives are to be read
+    response = nomad_search(
+        user_id=data.user_id,
+        owner=data.owner,
+        query=data.query,
+        required=MetadataRequired(include=['entry_id', 'upload_id']),
+        pagination=data.pagination,
+        aggregations={},  # aggregations support can be added later
+    )
+    entries: list = [
+        {
+            'entry_id': entry['entry_id'],
+            'upload_id': entry['upload_id'],
+        }
+        for entry in response.data
+    ]
+    entries = entries[: data.max_entries_export_limit]  #  Apply max limit
+
+    # setup required reader and archives list
+    required_reader = RequiredReader(data.required, user=User(user_id=data.user_id))
+    entry_archives = []
+
+    # For each entry
+    with _Uploads() as uploads:
+        for entry in entries:
+            entry_archive = _read_entry_from_archive(entry, uploads, required_reader)
+            entry_archives.append(entry_archive)
+
+    end = datetime.now(timezone.utc).isoformat()
+
+    if entry_archives:
+        write_file_func = {
+            'parquet': write_parquet_file,
+            'json': write_json_file,
+        }.get(data.batch_file_type)
+        write_file_func(path=data.output_file_path, data=entry_archives)
+
+    return SearchPageOutput(
+        search_start_time=start,
+        search_end_time=end,
+        num_entries_exported=len(entry_archives),
     )
 
 

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -41,6 +41,11 @@ class SearchSettings(BaseModel):
         description='List of fields to include in the search results. For example: '
         'results*, data.results*',
     )
+    required_include_resolved: list[str] = Field(
+        [],
+        description='Paths to include, along with resolved referencs, in the exported '
+        'dataset. For example: results*, data.results*',
+    )
     required_exclude: list[str] = Field(
         [],
         description='List of fields to exclude from the search results. For example: '
@@ -78,6 +83,15 @@ class CreateArtifactSubdirectoryInput(BaseModel):
     subdir_name: str = Field(..., description='Name of the subdirectory to be created.')
 
 
+class Required(MetadataRequired):
+    include_resolved: list[str] | None = Field(
+        None,
+        description='Quantities to include for each result. If the quantities include '
+        'references to other sections, the references will be resolved.'
+        'For example: results*, data.results*',
+    )
+
+
 class SearchPageInput(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
@@ -85,9 +99,9 @@ class SearchPageInput(BaseModel):
     read_archives: bool = Field(
         ...,
         description='Read full archive data, including non-indexed fields such as '
-        'n-dim arrays.'
+        'n-dim arrays.',
     )
-    required: MetadataRequired = Field(
+    required: Required = Field(
         ..., description='Required fields for filtering the search results.'
     )
     pagination: MetadataPagination = Field(
@@ -121,13 +135,19 @@ class SearchPageInput(BaseModel):
             _clean_field(user_input.search_settings.query).replace("'", '"')
         )
 
-        required = MetadataRequired()
+        required = Required()
         if user_input.search_settings.required_include:
             include = [
                 _clean_field(field)
                 for field in user_input.search_settings.required_include
             ]
             required.include = include if include else None
+        if user_input.search_settings.required_include_resolved:
+            include_resolved = [
+                _clean_field(field)
+                for field in user_input.search_settings.required_include_resolved
+            ]
+            required.include_resolved = include_resolved if include_resolved else None
         if user_input.search_settings.required_exclude:
             exclude = [
                 _clean_field(field)
@@ -157,29 +177,83 @@ class SearchPageInput(BaseModel):
 class ReadArchivesInput(SearchPageInput):
     required: str | dict[str, Any] = Field(
         '*',
-        description='Dictionary of required fields compatible with '
+        description='Dictionary of required fields and directives compatible with '
         '`nomad.archive.required.RequiredReader` class.',
     )
 
     @staticmethod
-    def _build_archive_required(metadata_required: MetadataRequired) -> str | dict:
+    def build_archive_required(required: Required) -> str | dict:
         """
-        Convert dot-separated include and exclude paths into an ArchiveRequired
-        specification following the documented RequiredReader structure.
+        Convert dot-separated required paths into a nested-dict structure with
+        directives on the leaf. Output can be used when instantiating the
+        `nomad.archive.required.RequiredReader` class.
 
-        Examples::
+        Adds the following directives at the dict nodes:
+            - "include"             (for `required.include` list)
+            - "include-resolved"    (for `required.include_resolved` list)
 
-            ["data"]                   -> {"data": "*"}
-            ["data.results"]           -> {"data": {"results": "*"}}
-            ["data", "data.results"]   -> {"data": "*"}  (parent wins)
-            ["*"]                      -> "*"
-            [], ["data.results"]       -> {"*": "*", "data": {"*": "*", "results":"exclude"}}
+        Ignores the `required.exclude` list, since there is no support for
+        "exclude" directives.
+
+        If the required lists are empty, returns "*", meaning to include everything.
+
+        Examples:
+            - When required.include is:
+                []                         -> "*"
+                ["data"]                   -> {"data": "include"}
+                ["data.num_val"]           -> {"data": {"num_val": "include"}}
+                ["data.sub_sec"]           -> {"data": {"sub_sec": "include"}}
+                ["data.sub_sec*"]          -> {"data": {"sub_sec": "include"}}
+                                            (remove trailing *)
+                ["data", "data.sub_sec"]   -> {"data": "*"}
+                                            (parent wins)
+
+        For `required.include_resolved`, the directive changes to "include-resolved",
+        but the conversion follows the same logic.
+
+        When same fields are present in `required.include` and
+        `required.include_resolved`, "include-resolved" directive takes priority.
         """
-        if not metadata_required.include and metadata_required.exclude:
-            return '*'
-        return '*'
+        include = required.include or []
+        include_resolved = required.include_resolved or []
 
-        # TODO: engage the conversion
+        if not include and not include_resolved:
+            return '*'  # include everything
+
+        def _remove_wildcard(require_list: list) -> list:
+            return [el[:-1] if el.endswith('*') else el for el in require_list]
+
+        def _path_parts(path: str) -> list[str]:
+            return [part for part in path.split('.') if part]
+
+        def _add_include(
+            target: dict[str, Any], path: str, directive='include'
+        ) -> None:
+            node = target
+            parts = _path_parts(path)
+            for index, part in enumerate(parts):
+                is_leaf = index == len(parts) - 1
+                if is_leaf:
+                    node[part] = directive
+                    return
+                child = node.get(part)
+                if child == directive:
+                    return
+                if not isinstance(child, dict):
+                    child = {}
+                    node[part] = child
+                node = child
+
+        include = _remove_wildcard(include)
+        include_resolved = _remove_wildcard(include_resolved)
+
+        archive_required = {}
+        for path in include:
+            _add_include(archive_required, path, directive='include')
+        for path in include_resolved:
+            _add_include(archive_required, path, directive='include-resolved')
+
+        return archive_required
 
     @classmethod
     def from_search_page_input(
@@ -188,7 +262,7 @@ class ReadArchivesInput(SearchPageInput):
     ) -> 'ReadArchivesInput':
         """Convert from SearchPageInput to ReadArchivesInput"""
 
-        required = ReadArchivesInput._build_archive_required(spi.required)
+        required = ReadArchivesInput.build_archive_required(spi.required)
 
         return cls(
             user_id=spi.user_id,
@@ -201,8 +275,6 @@ class ReadArchivesInput(SearchPageInput):
             output_file_path=spi.output_file_path,
             max_entries_export_limit=spi.max_entries_export_limit,
         )
-
-
 
 
 class SearchPageOutput(BaseModel):

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -194,6 +194,7 @@ class ReadArchivesInput(SearchPageInput):
             user_id=spi.user_id,
             owner=spi.owner,
             query=spi.query,
+            read_archives=spi.read_archives,
             required=required,
             pagination=spi.pagination,
             batch_file_type=spi.batch_file_type,

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -44,6 +44,11 @@ class SearchSettings(BaseModel):
 
 
 class OutputSettings(BaseModel):
+    read_archives: bool = Field(
+        False,
+        description='Read full archive data, including non-indexed fields such as '
+        'n-dim arrays. Disable to export only indexed fields faster.',
+    )
     output_file_type: OutputFileTypeLiteral = Field(
         'parquet',
         description='Type of the output file.',
@@ -77,6 +82,11 @@ class SearchPageInput(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
     query: Query = Field(..., description='Search query parameters.')
+    read_archives: bool = Field(
+        ...,
+        description='Read full archive data, including non-indexed fields such as '
+        'n-dim arrays.'
+    )
     required: MetadataRequired = Field(
         ..., description='Required fields for filtering the search results.'
     )
@@ -90,7 +100,6 @@ class SearchPageInput(BaseModel):
     max_entries_export_limit: int = Field(
         ..., description='Maximum number of entries to be exported.'
     )
-    read_from_archives: bool = Field(False)
 
     @classmethod
     def from_user_input(

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -44,14 +44,14 @@ class SearchSettings(BaseModel):
 
 
 class OutputSettings(BaseModel):
+    output_file_type: OutputFileTypeLiteral = Field(
+        'parquet',
+        description='Type of the output file.',
+    )
     read_archives: bool = Field(
         False,
         description='Read full archive data, including non-indexed fields such as '
         'n-dim arrays. Disable to export only indexed fields faster.',
-    )
-    output_file_type: OutputFileTypeLiteral = Field(
-        'parquet',
-        description='Type of the output file.',
     )
     zip_output: bool = Field(
         True,
@@ -145,6 +145,7 @@ class SearchPageInput(BaseModel):
             user_id=user_input.user_id,
             owner=user_input.search_settings.owner,
             query=query,
+            read_archives=user_input.output_settings.read_archives,
             required=required,
             pagination=pagination,
             batch_file_type=batch_file_type,

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -31,6 +31,11 @@ class SearchSettings(BaseModel):
             'uiSchema': {'ui:widget': 'textarea', 'ui:options': {'rows': 5}}
         },
     )
+    read_archives: bool = Field(
+        False,
+        description='Read full archive data, including non-indexed fields such as '
+        'n-dim arrays. Disable to export only indexed fields faster.',
+    )
     required_include: list[str] = Field(
         [],
         description='List of fields to include in the search results. For example: '
@@ -47,11 +52,6 @@ class OutputSettings(BaseModel):
     output_file_type: OutputFileTypeLiteral = Field(
         'parquet',
         description='Type of the output file.',
-    )
-    read_archives: bool = Field(
-        False,
-        description='Read full archive data, including non-indexed fields such as '
-        'n-dim arrays. Disable to export only indexed fields faster.',
     )
     zip_output: bool = Field(
         True,
@@ -145,7 +145,7 @@ class SearchPageInput(BaseModel):
             user_id=user_input.user_id,
             owner=user_input.search_settings.owner,
             query=query,
-            read_archives=user_input.output_settings.read_archives,
+            read_archives=user_input.search_settings.read_archives,
             required=required,
             pagination=pagination,
             batch_file_type=batch_file_type,

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -1,5 +1,5 @@
 import json
-from typing import Literal
+from typing import Any, Literal
 
 from nomad.app.v1.models.models import MetadataPagination, MetadataRequired, Query
 from pydantic import BaseModel, Field
@@ -90,6 +90,7 @@ class SearchPageInput(BaseModel):
     max_entries_export_limit: int = Field(
         ..., description='Maximum number of entries to be exported.'
     )
+    read_from_archives: bool = Field(False)
 
     @classmethod
     def from_user_input(
@@ -141,6 +142,34 @@ class SearchPageInput(BaseModel):
             output_file_path=output_file_path,
             max_entries_export_limit=max_entries_export_limit,
         )
+
+
+class ReadArchivesInput(SearchPageInput):
+    required: str | dict[str, Any] = Field(
+        '*',
+        description='Dictionary of required fields compatible with '
+        '`nomad.archive.required.RequiredReader` class.',
+    )
+
+    @staticmethod
+    def _build_archive_required(metadata_required: MetadataRequired) -> str | dict:
+        """
+        Convert dot-separated include and exclude paths into an ArchiveRequired
+        specification following the documented RequiredReader structure.
+
+        Examples::
+
+            ["data"]                   -> {"data": "*"}
+            ["data.results"]           -> {"data": {"results": "*"}}
+            ["data", "data.results"]   -> {"data": "*"}  (parent wins)
+            ["*"]                      -> "*"
+            [], ["data.results"]       -> {"*": "*", "data": {"*": "*", "results":"exclude"}}
+        """
+        if not metadata_required.include and metadata_required.exclude:
+            return '*'
+        return '*'
+
+        # TODO: engage the conversion
 
 
 class SearchPageOutput(BaseModel):

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -180,6 +180,28 @@ class ReadArchivesInput(SearchPageInput):
 
         # TODO: engage the conversion
 
+    @classmethod
+    def from_search_page_input(
+        cls,
+        spi: SearchPageInput,
+    ) -> 'ReadArchivesInput':
+        """Convert from SearchPageInput to ReadArchivesInput"""
+
+        required = ReadArchivesInput._build_archive_required(spi.required)
+
+        return cls(
+            user_id=spi.user_id,
+            owner=spi.search_settings.owner,
+            query=spi.query,
+            required=required,
+            pagination=spi.pagination,
+            batch_file_type=spi.batch_file_type,
+            output_file_path=spi.output_file_path,
+            max_entries_export_limit=spi.max_entries_export_limit,
+        )
+
+
+
 
 class SearchPageOutput(BaseModel):
     num_entries_exported: int = Field(

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -192,7 +192,7 @@ class ReadArchivesInput(SearchPageInput):
 
         return cls(
             user_id=spi.user_id,
-            owner=spi.search_settings.owner,
+            owner=spi.owner,
             query=spi.query,
             required=required,
             pagination=spi.pagination,

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -73,7 +73,7 @@ class CreateArtifactSubdirectoryInput(BaseModel):
     subdir_name: str = Field(..., description='Name of the subdirectory to be created.')
 
 
-class SearchInput(BaseModel):
+class SearchPageInput(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
     query: Query = Field(..., description='Search query parameters.')
@@ -98,8 +98,8 @@ class SearchInput(BaseModel):
         /,
         output_file_path: str,
         max_entries_export_limit: int,
-    ) -> 'SearchInput':
-        """Convert from ExportEntriesUserInput to SearchInput"""
+    ) -> 'SearchPageInput':
+        """Convert from ExportEntriesUserInput to SearchPageInput"""
 
         def _clean_field(field: str) -> str:
             """
@@ -143,15 +143,15 @@ class SearchInput(BaseModel):
         )
 
 
-class SearchOutput(BaseModel):
+class SearchPageOutput(BaseModel):
     num_entries_exported: int = Field(
         ..., description='Number of entries exported to the output file.'
     )
     search_start_time: str = Field(
-        ..., description='UTC Timestamp (ISO) when the search started.'
+        ..., description='UTC Timestamp (ISO) when the first search started.'
     )
     search_end_time: str = Field(
-        ..., description='UTC Timestamp (ISO) when the search completed.'
+        ..., description='UTC Timestamp (ISO) when the last search completed.'
     )
 
 

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -110,7 +110,7 @@ class ExportEntriesWorkflow:
 
             # Build a representative SearchPageInput to resolve shared settings
             # (query, owner, required, batch_file_type) once.
-            template_spi = SearchPageInput.from_search_page_input(
+            template_spi = SearchPageInput.from_user_input(
                 data,
                 output_file_path='',  # placeholder, real paths are set per page below
                 max_entries_export_limit=config.max_entries_export_limit,

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -49,7 +49,7 @@ class SearchPageWorkflow:
         )
         retry_policy = RetryPolicy(maximum_attempts=1)
 
-        if data.read_from_archives:
+        if data.read_archives:
             rai = ReadArchivesInput.from_search_page_input(data)
             return await workflow.execute_activity(
                 read_archives,

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -25,8 +25,8 @@ with workflow.unsafe.imports_passed_through():
         ExportDatasetMetadata,
         ExportEntriesUserInput,
         MergeOutputFilesInput,
-        SearchInput,
-        SearchOutput,
+        SearchPageInput,
+        SearchPageOutput,
     )
 
 
@@ -41,7 +41,7 @@ class SearchPageWorkflow:
     """
 
     @workflow.run
-    async def run(self, data: SearchInput) -> SearchOutput:
+    async def run(self, data: SearchPageInput) -> SearchPageOutput:
         config = nomad_config.get_plugin_entry_point(
             'nomad_ml_workflows.actions:export_entries'
         )
@@ -96,9 +96,9 @@ class ExportEntriesWorkflow:
                 'nomad_ml_workflows.actions:export_entries'
             )
 
-            # Build a representative SearchInput to resolve shared settings
+            # Build a representative SearchPageInput to resolve shared settings
             # (query, owner, required, batch_file_type) once.
-            template_search_input = SearchInput.from_user_input(
+            template_spi = SearchPageInput.from_search_page_input(
                 data,
                 output_file_path='',  # placeholder, real paths are set per page below
                 max_entries_export_limit=config.max_entries_export_limit,
@@ -111,7 +111,7 @@ class ExportEntriesWorkflow:
                 CollectCursorsInput(
                     user_id=data.user_id,
                     owner=data.search_settings.owner,
-                    query=template_search_input.query,
+                    query=template_spi.query,
                     page_size=page_size,
                     max_entries_export_limit=config.max_entries_export_limit,
                 ),
@@ -128,19 +128,19 @@ class ExportEntriesWorkflow:
                 # No pages to export, return early with an empty dataset
                 return
 
-            # Build one SearchInput per page with the corresponding cursor and
+            # Build one SearchPageInput per page with the corresponding cursor and
             # export limit for that page
-            search_inputs: list[SearchInput] = []
+            search_page_inputs: list[SearchPageInput] = []
             for page_index, cursor in enumerate(cursors_output.page_after_values):
                 entries_so_far = page_index * page_size
                 limit_for_page = min(
                     page_size, config.max_entries_export_limit - entries_so_far
                 )
-                si = template_search_input.model_copy(
+                spi = template_spi.model_copy(
                     update={
                         'output_file_path': (
                             f'{artifact_subdirectory}/{page_index + 1}'
-                            f'.{template_search_input.batch_file_type}'
+                            f'.{template_spi.batch_file_type}'
                         ),
                         'max_entries_export_limit': limit_for_page,
                         'pagination': MetadataPagination(
@@ -149,51 +149,51 @@ class ExportEntriesWorkflow:
                         ),
                     }
                 )
-                search_inputs.append(si)
+                search_page_inputs.append(spi)
 
             # Run child workflows for each page with bounded concurrency to avoid
-            # overwhelming the Temporal server with too many concurrent searches.
-            search_outputs: list[SearchOutput] = []
+            # overwhelming the Temporal server with too many concurrent workflows.
+            search_page_outputs: list[SearchPageOutput] = []
             for concurr_batch_start in range(
-                0, len(search_inputs), config.search_workflow_concurrency_limit
+                0, len(search_page_inputs), config.search_workflow_concurrency_limit
             ):
-                concurr_batch_search_inputs = search_inputs[
+                concurr_batch_spis = search_page_inputs[
                     concurr_batch_start : concurr_batch_start
                     + config.search_workflow_concurrency_limit
                 ]
-                concurr_batch_outputs = await asyncio.gather(
+                concurr_batch_spos = await asyncio.gather(
                     *[
                         workflow.execute_child_workflow(
                             SearchPageWorkflow.run,
-                            si,
+                            spi,
                             id=f'{workflow.info().workflow_id}-search-page-'
                             f'{concurr_batch_start + i + 1}',
                             parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
                             retry_policy=retry_policy,
                         )
-                        for i, si in enumerate(concurr_batch_search_inputs)
+                        for i, spi in enumerate(concurr_batch_spis)
                     ]
                 )
-                search_outputs.extend(concurr_batch_outputs)
+                search_page_outputs.extend(concurr_batch_spos)
 
             # Pages ran concurrently so take the earliest start and latest end. ISO
             # timestamp strings can be compared lexicographically
             export_dataset_input.metadata.num_entries_exported = sum(
-                so.num_entries_exported for so in search_outputs
+                spo.num_entries_exported for spo in search_page_outputs
             )
             export_dataset_input.metadata.search_start_time = min(
-                [so.search_start_time for so in search_outputs]
+                [spo.search_start_time for spo in search_page_outputs]
             )
             export_dataset_input.metadata.search_end_time = max(
-                [so.search_end_time for so in search_outputs]
+                [spo.search_end_time for spo in search_page_outputs]
             )
 
             # Merge batch files into one file to be exported
             # Only include paths where entries were actually written to disk
             generated_file_paths = [
-                search_inputs[i].output_file_path
-                for i, so in enumerate(search_outputs)
-                if so.num_entries_exported > 0
+                search_page_inputs[i].output_file_path
+                for i, spo in enumerate(search_page_outputs)
+                if spo.num_entries_exported > 0
             ]
             merged_file_path = await workflow.execute_activity(
                 merge_output_files,

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -15,6 +15,7 @@ with workflow.unsafe.imports_passed_through():
         create_artifact_subdirectory,
         export_dataset_to_upload,
         merge_output_files,
+        read_archives,
         search,
     )
     from nomad_ml_workflows.actions.export_entries.models import (
@@ -25,6 +26,7 @@ with workflow.unsafe.imports_passed_through():
         ExportDatasetMetadata,
         ExportEntriesUserInput,
         MergeOutputFilesInput,
+        ReadArchivesInput,
         SearchPageInput,
         SearchPageOutput,
     )
@@ -46,6 +48,16 @@ class SearchPageWorkflow:
             'nomad_ml_workflows.actions:export_entries'
         )
         retry_policy = RetryPolicy(maximum_attempts=1)
+
+        if data.read_from_archives:
+            rai = ReadArchivesInput.from_search_page_input(data)
+            return await workflow.execute_activity(
+                read_archives,
+                rai,
+                start_to_close_timeout=timedelta(seconds=config.search_batch_timeout),
+                retry_policy=retry_policy,
+            )
+
         return await workflow.execute_activity(
             search,
             data,

--- a/tests/actions/export_entries/test_models.py
+++ b/tests/actions/export_entries/test_models.py
@@ -1,0 +1,46 @@
+from nomad_ml_workflows.actions.export_entries.models import ReadArchivesInput, Required
+
+
+def test_build_archive_required_returns_wildcard_for_empty_paths():
+    assert ReadArchivesInput.build_archive_required(Required()) == '*'
+
+
+def test_build_archive_required_builds_nested_include_tree():
+    required = Required(include=['data.results.energy'])
+
+    assert ReadArchivesInput.build_archive_required(required) == {
+        'data': {'results': {'energy': 'include'}}
+    }
+
+
+def test_build_archive_required_prefers_parent_include():
+    required = Required(include=['data', 'data.results'])
+
+    assert ReadArchivesInput.build_archive_required(required) == {'data': 'include'}
+
+
+def test_build_archive_required_strips_include_wildcard_suffix():
+    required = Required(include=['data.results*'])
+
+    assert ReadArchivesInput.build_archive_required(required) == {
+        'data': {'results': 'include'}
+    }
+
+
+def test_build_archive_required_builds_include_resolved_directive():
+    required = Required(include_resolved=['data.results.energy'])
+
+    assert ReadArchivesInput.build_archive_required(required) == {
+        'data': {'results': {'energy': 'include-resolved'}}
+    }
+
+
+def test_build_archive_required_prefers_include_resolved_for_same_path():
+    required = Required(
+        include=['data.results.energy'],
+        include_resolved=['data.results.energy'],
+    )
+
+    assert ReadArchivesInput.build_archive_required(required) == {
+        'data': {'results': {'energy': 'include-resolved'}}
+    }


### PR DESCRIPTION
- Adds `read_archives` activity that can be triggered on demand by the user using a `read_archives` bool field in the Action form. This brings the following support:
  - exporting non-indexed quantities, like arrays/lists
  - exporting resolved references (based on the `required_include_resolved: list[str]` field in the Action form)
  Resolution happens in-place, so the reference path is replaced by the data dict.
- `read_archives` activity relies on the following:
  - `nomad.app.v1.routers.entries._read_entry_from_archive`
  - `nomad.app.v1.routers.entries._Uploads`
  - `nomad.archive.required.RequiredReader`
- Adds `ReadArchivesInput` which converts the required lists into a `dict` containing directives that can be used in the `RequiredReader`
- Renames the `SearchPageWorkflow` input and output models