### PR TITLE
Write pyarrow tables with NOMAD schema awareness

### DIFF
--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -9,6 +9,7 @@ from nomad.actions.manager import action_artifacts_dir, get_upload_files
 from nomad.app.v1.models.models import MetadataPagination, MetadataRequired, User
 from nomad.files import StagingUploadFiles
 from nomad.search import search as nomad_search
+from nomad.utils import get_logger
 from temporalio import activity
 
 from nomad_ml_workflows.actions.export_entries.models import (
@@ -27,6 +28,8 @@ from nomad_ml_workflows.actions.export_entries.utils import (
     write_json_file,
     write_parquet_file,
 )
+
+logger = get_logger(__name__)
 
 
 @activity.defn
@@ -91,7 +94,7 @@ async def search(data: SearchPageInput) -> SearchPageOutput:
     entry_list = response.data[: data.max_entries_export_limit]
 
     if entry_list:
-        write_dataset_file(path=data.output_file_path, data=entry_list)
+        write_dataset_file(path=data.output_file_path, data=entry_list, logger=logger)
 
     return SearchPageOutput(
         search_start_time=start,
@@ -220,17 +223,33 @@ async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
     # For each entry
     with _Uploads() as uploads:
         for entry in entries:
-            entry_archive = _read_entry_from_archive(entry, uploads, required_reader)
-            entry_archives.append(entry_archive)
+            try:
+                entry_archive = _read_entry_from_archive(
+                    entry, uploads, required_reader
+                )
+                entry_archives.append(entry_archive)
+            except Exception as e:
+                logger.error(
+                    'failed to read entry archive',
+                    entry_id=entry['entry_id'],
+                    exc_info=e,
+                )
 
     end = datetime.now(timezone.utc).isoformat()
 
+    write_dataset_file = {
+        'parquet': write_parquet_file,
+        'json': write_json_file,
+    }.get(data.batch_file_format)
+    if write_dataset_file is None:
+        raise ValueError(f'Unsupported batch file format "{data.batch_file_format}". ')
+
     if entry_archives:
-        write_file_func = {
-            'parquet': write_parquet_file,
-            'json': write_json_file,
-        }.get(data.batch_file_format)
-        write_file_func(path=data.output_file_path, data=entry_archives)
+        write_dataset_file(
+            path=data.output_file_path,
+            data=entry_archives,
+            logger=logger,
+        )
 
     return SearchPageOutput(
         search_start_time=start,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -71,6 +71,12 @@ async def search(data: SearchPageInput) -> SearchPageOutput:
     Returns:
         SearchOutput: Output data from the search activity.
     """
+    info = activity.info()
+
+    activity_logger = logger.bind(
+        activity_type=info.activity_type,
+        search_page_num=data.page_num,
+    )
 
     write_dataset_file = {
         'parquet': write_parquet_file,
@@ -94,12 +100,18 @@ async def search(data: SearchPageInput) -> SearchPageOutput:
     entry_list = response.data[: data.max_entries_export_limit]
 
     if entry_list:
-        write_dataset_file(path=data.output_file_path, data=entry_list, logger=logger)
+        num_entries_exported = write_dataset_file(
+            path=data.output_file_path, data=entry_list, logger=activity_logger
+        )
+    else:
+        num_entries_exported = 0
+
+    activity_logger.info(f'exported {num_entries_exported}/{len(entry_list)} entries')
 
     return SearchPageOutput(
         search_start_time=start,
         search_end_time=end,
-        num_entries_exported=len(entry_list),
+        num_entries_exported=num_entries_exported,
     )
 
 
@@ -195,6 +207,13 @@ async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
 
     start = datetime.now(timezone.utc).isoformat()
 
+    info = activity.info()
+
+    activity_logger = logger.bind(
+        activity_type=info.activity_type,
+        search_page_num=data.page_num,
+    )
+
     # Find entries whose archives are to be read
     response = nomad_search(
         user_id=data.user_id,
@@ -229,7 +248,7 @@ async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
                 )
                 entry_archives.append(entry_archive)
             except Exception as e:
-                logger.error(
+                activity_logger.error(
                     'failed to read entry archive',
                     entry_id=entry['entry_id'],
                     exc_info=e,
@@ -245,16 +264,22 @@ async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
         raise ValueError(f'Unsupported batch file format "{data.batch_file_format}". ')
 
     if entry_archives:
-        write_dataset_file(
+        num_entries_exported = write_dataset_file(
             path=data.output_file_path,
             data=entry_archives,
-            logger=logger,
+            logger=activity_logger,
         )
+    else:
+        num_entries_exported = 0
+
+    activity_logger.info(
+        f'exported {num_entries_exported}/{len(entry_archives)} entries'
+    )
 
     return SearchPageOutput(
         search_start_time=start,
         search_end_time=end,
-        num_entries_exported=len(entry_archives),
+        num_entries_exported=num_entries_exported,
     )
 
 

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -113,12 +113,14 @@ class SearchPageInput(BaseModel):
     max_entries_export_limit: int = Field(
         ..., description='Maximum number of entries to be exported.'
     )
+    page_num: int = Field(..., description='Page number for the search results.')
 
     @classmethod
     def from_user_input(
         cls,
         user_input: ExportEntriesUserInput,
         /,
+        page_num: int,
         output_file_path: str,
         max_entries_export_limit: int,
     ) -> 'SearchPageInput':
@@ -168,6 +170,7 @@ class SearchPageInput(BaseModel):
             required=required,
             pagination=pagination,
             batch_file_format=batch_file_format,
+            page_num=page_num,
             output_file_path=output_file_path,
             max_entries_export_limit=max_entries_export_limit,
         )
@@ -271,6 +274,7 @@ class ReadArchivesInput(SearchPageInput):
             required=required,
             pagination=spi.pagination,
             batch_file_format=spi.batch_file_format,
+            page_num=spi.page_num,
             output_file_path=spi.output_file_path,
             max_entries_export_limit=spi.max_entries_export_limit,
         )

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -301,7 +301,8 @@ def _archives_to_rows(
     Flatten list of archive dicts into list of row dicts. Also returns column definition
     and a count of unhandled archive dict keys.
 
-    Shape of one archive dict corresponds to serialization of EntryArchive::
+    Each element in the `archives` list should have the following structure, where
+    `archive` key corresponds to serialization of EntryArchive::
         {
             "entry_id": str,
             "archive": {
@@ -338,7 +339,7 @@ def _archives_to_rows(
         )
         try:
             _flatten_section(
-                section_data=item,
+                section_data=item['archive'],
                 section_def=EntryArchive.m_def,
                 prefix='',
                 context=context,

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -1,12 +1,14 @@
 import importlib
 import json
 from collections import Counter
+from dataclasses import dataclass
 from functools import lru_cache
 
 import json_stream
 import pandas as pd
 from nomad.datamodel.datamodel import EntryArchive
-from nomad.metainfo.metainfo import Section
+from nomad.metainfo import data_type as nomad_data_type
+from nomad.metainfo.metainfo import Quantity, Reference, Section
 
 try:
     import pyarrow as pa
@@ -19,6 +21,19 @@ except ImportError as e:
     ) from e
 
 IGNORED_KEYS = ['m_def', 'm_def_id', 'm_ref_archives']
+
+
+@dataclass(frozen=True)
+class _ArrowColumnConfig:
+    arrow_type: pa.DataType
+    stringify_json: bool = False
+
+
+@dataclass
+class _FlattenContext:
+    columns_quantity_def: dict[str, Quantity]
+    unhandled_keys: Counter
+
 
 def _join_path(prefix: str, key: str) -> str:
     return f'{prefix}.{key}' if prefix else key
@@ -58,6 +73,152 @@ def _resolve_section_def(m_def: str | None) -> Section | None:
     # return definition if isinstance(definition, Section) else None
 
 
+def _quantity_to_arrow_column_config(quantity_def: Quantity) -> _ArrowColumnConfig:
+    """Create an Arrow column config from a NOMAD quantity definition."""
+    quantity_type = quantity_def.type
+
+    if isinstance(quantity_type, Reference):
+        return _ArrowColumnConfig(pa.string(), stringify_json=True)
+
+    if isinstance(quantity_type, nomad_data_type.JSON | nomad_data_type.Any):
+        return _ArrowColumnConfig(pa.string(), stringify_json=True)
+
+    try:
+        standard_type = quantity_type.standard_type()
+    except (AttributeError, NotImplementedError, TypeError, ValueError):
+        return _ArrowColumnConfig(pa.string(), stringify_json=True)
+
+    primitive_types = {
+        'int8': pa.int8(),
+        'int16': pa.int16(),
+        'int32': pa.int32(),
+        'int64': pa.int64(),
+        'float16': pa.float32(),  # Parquet has no native half-float representation
+        'float32': pa.float32(),
+        'float64': pa.float64(),
+        'bool': pa.bool_(),
+        'str': pa.string(),
+        'enum': pa.string(),
+        'datetime': pa.timestamp('us', tz='UTC'),
+        'bytes': pa.string(),  # NOMAD serializes bytes as base64 ASCII text
+    }
+    arrow_type = primitive_types.get(standard_type)
+    if arrow_type is None or standard_type.startswith('complex'):
+        return _ArrowColumnConfig(pa.string(), stringify_json=True)
+
+    for _ in quantity_def.shape or []:
+        # adds a dimension per `shape: list` element.
+        arrow_type = pa.list_(arrow_type)
+
+    return _ArrowColumnConfig(arrow_type)
+
+
+def _json_stringify(value):
+    """Encode value as compact JSON text."""
+    if value is None:
+        return None
+    return json.dumps(value, sort_keys=True, separators=(',', ':'))
+
+
+def _cast_arrow_value(value, arrow_type: pa.DataType):
+    """
+    Cast a scalar or nested list recursively using Arrow's safe casts.
+
+    Arrow can cast homogeneous lists directly, but cannot infer a source type for
+    heterogeneous lists. Recursion lets each list element be cast independently.
+    """
+    if value is None:
+        return None
+    if pa.types.is_list(arrow_type):
+        if not isinstance(value, list | tuple) and hasattr(value, 'tolist'):
+            value = value.tolist()
+        if not isinstance(value, list | tuple):
+            raise TypeError(f'{value!r} is not a list.')
+        return [_cast_arrow_value(item, arrow_type.value_type) for item in value]
+    return pa.scalar(value).cast(arrow_type, safe=True).as_py()
+
+
+def _normalize_arrow_column(
+    values: list,
+    config: _ArrowColumnConfig,
+    column_name: str,
+) -> pa.Array:
+    """
+    Build a typed Arrow array. It converts mismatched values, when needed, using Arrow's
+    safe cast.
+    """
+    if config.stringify_json:
+        try:
+            return pa.array(
+                [_json_stringify(value) for value in values],
+                type=config.arrow_type,
+            )
+        except (TypeError, ValueError) as error:
+            raise ValueError(
+                f'Cannot JSON-encode values in column {column_name!r}.'
+            ) from error
+
+    try:
+        return pa.array(values, type=config.arrow_type, safe=True)
+    except (
+        pa.ArrowInvalid,
+        pa.ArrowNotImplementedError,
+        pa.ArrowTypeError,
+        OverflowError,
+    ):
+        pass
+
+    converted_values = []
+    for row_index, value in enumerate(values):
+        if value is None:
+            converted_values.append(None)
+            continue
+
+        try:
+            converted_values.append(_cast_arrow_value(value, config.arrow_type))
+        except (
+            pa.ArrowInvalid,
+            pa.ArrowNotImplementedError,
+            pa.ArrowTypeError,
+            OverflowError,
+            TypeError,
+            ValueError,
+        ) as error:
+            raise ValueError(
+                f'Cannot convert row {row_index} of column {column_name!r} '
+                f'to {config.arrow_type}: {value!r}.'
+            ) from error
+
+    return pa.array(
+        converted_values,
+        type=config.arrow_type,
+        safe=True,
+    )
+
+
+def _infer_arrow_column(values: list, column_name: str) -> pa.Array:
+    """Infer non-schema column types, falling back to deterministic JSON text."""
+    try:
+        array = pa.array(values)
+        return array
+    except (
+        pa.ArrowInvalid,
+        pa.ArrowNotImplementedError,
+        pa.ArrowTypeError,
+        OverflowError,
+        TypeError,
+        ValueError,
+    ):
+        try:
+            return pa.array(
+                [_json_stringify(value) for value in values], type=pa.string()
+            )
+        except (TypeError, ValueError) as error:
+            raise ValueError(
+                f'Cannot infer or JSON-encode column {column_name!r}.'
+            ) from error
+
+
 def _flatten_generic(value, prefix: str, row: dict):
     """Flatten generic nested data while keeping non-dict lists as leaf values."""
     if isinstance(value, dict):
@@ -82,7 +243,7 @@ def _flatten_section(
     section_def: Section,
     prefix: str,
     row: dict,
-    unhandled_keys: Counter,
+    context: _FlattenContext,
 ):
     """
     Flatten one serialized NOMAD section using its metainfo definition.
@@ -93,11 +254,12 @@ def _flatten_section(
     """
     handled_keys = set()
 
-    for quantity_name in section_def.all_quantities:
+    for quantity_name, quantity_def in section_def.all_quantities.items():
         if quantity_name not in section_data:
             continue
         handled_keys.add(quantity_name)
         col = _join_path(prefix, quantity_name) + '#' + section_def.qualified_name()
+        context.columns_quantity_def.setdefault(col, quantity_def)
         _store_leaf_value(row, col, section_data[quantity_name])
 
     for sub_section_name, sub_section_def in section_def.all_sub_sections.items():
@@ -124,7 +286,7 @@ def _flatten_section(
                     item_section_def or child_section_def,
                     item_prefix,
                     row,
-                    unhandled_keys,
+                    context,
                 )
         else:
             # If m_def is available in the dict, get a section_def based on it.
@@ -136,36 +298,24 @@ def _flatten_section(
                 item_section_def or child_section_def,
                 sub_section_prefix,
                 row,
-                unhandled_keys,
+                context,
             )
 
     # Add the unhandled keys to the counter. These point to the obsolete data in the
     # archives that do not correspond to a subsection/quantity in the current schema
     for key, _ in section_data.items():
         if key not in [*handled_keys, *IGNORED_KEYS]:
-            unhandled_keys.update([f'{prefix}.{key}#{section_def.qualified_name()}'])
+            context.unhandled_keys.update(
+                [f'{prefix}.{key}#{section_def.qualified_name()}']
+            )
 
 
-def archives_to_dataframe(archives: list[dict] | dict) -> tuple[pd.DataFrame, Counter]:
+def _archives_to_rows(
+    archives: list[dict] | dict,
+) -> tuple[list[dict], dict[str, Quantity], Counter]:
     """
-    Convert exported entries to a DataFrame.
-
-    Each input item is expected to be a dict containing a serialized `archive`
-    entry alongside optional top-level metadata fields. For example,
-
-    ```python
-    {
-        entry_id: ...,
-        upload_id: ...,
-        archive: {...}  # serialized EntryArchive instance 1
-    }
-    ```
-
-    The `archive` value is flattened using `EntryArchive` metainfo definitions;
-    recursion only follows subsections and every quantity becomes one DataFrame cell.
-    This keeps the DataFrame aligned with NOMAD section boundaries across the whole
-    archive, including `archive.data` where plugin-provided `m_def` values are
-    used to resolve the concrete section definition.
+    Flatten list of archive dicts into list of row dicts. Also returns column definition
+    and a count of unhandled archive dict keys.
     """
     if isinstance(archives, dict):
         archives = [archives]
@@ -176,7 +326,7 @@ def archives_to_dataframe(archives: list[dict] | dict) -> tuple[pd.DataFrame, Co
         )
 
     rows = []
-    unhandled_keys = Counter()
+    context = _FlattenContext(columns_quantity_def={}, unhandled_keys=Counter())
     for item in archives:
         if not isinstance(item, dict):
             raise ValueError('Input must be a dictionary (JSON object).')
@@ -184,24 +334,88 @@ def archives_to_dataframe(archives: list[dict] | dict) -> tuple[pd.DataFrame, Co
         row = {}
         for key, value in item.items():
             if key != 'archive':
-                _flatten_generic(value, key, row)  #  TODO: remove this support, require list[archive]
+                # TODO: remove this support and require list[archive].
+                _flatten_generic(value, key, row)
                 continue
 
-            # `archive` always starts from the fixed EntryArchive definition.
             _flatten_section(
                 section_data=value,
                 section_def=EntryArchive.m_def,
                 prefix='',
                 row=row,
-                unhandled_keys=unhandled_keys,
+                context=context,
             )
 
         rows.append(row)
+
+    return rows, context.columns_quantity_def, context.unhandled_keys
+
+
+def archives_to_dataframe(archives: list[dict] | dict) -> tuple[pd.DataFrame, Counter]:
+    """
+    Convert serialized NOMAD entries into a flattened pandas DataFrame.
+
+    Archive traversal follows NOMAD metainfo subsections, while quantities remain
+    opaque cell values. Concrete ``m_def`` values are used to resolve schemas, and
+    pandas infers the resulting column dtypes from the flattened rows.
+    Columns are returned in alphabetical order.
+
+    Args:
+        archives: A serialized entry dictionary or list of entry dictionaries. Each
+            entry may contain an ``archive`` dictionary and optional top-level data.
+
+    Returns:
+        A tuple containing the flattened DataFrame and a counter of serialized archive
+        keys that are not quantities or subsections in the resolved NOMAD schemas.
+    """
+    rows, _, unhandled_keys = _archives_to_rows(archives)
 
     df = pd.DataFrame(rows)
     sorted_df = df.reindex(sorted(df.columns), axis=1)
 
     return sorted_df, unhandled_keys
+
+
+def archives_to_arrow_table(
+    archives: list[dict] | dict,
+) -> tuple[pa.Table, Counter]:
+    """
+    Convert serialized NOMAD entries into a schema-typed Arrow table.
+
+    Entries are flattened using the same metainfo-aware traversal as
+    :func:`archives_to_dataframe`. Schema-backed columns receive explicit Arrow types
+    derived from their quantity definitions, including nested list dimensions. Values
+    are safely cast when necessary; JSON, ``Any``, references, complex numbers, and
+    unsupported custom datatypes are stored as deterministic JSON strings. Columns
+    without a NOMAD quantity definition use Arrow inference with the same JSON fallback.
+
+    Args:
+        archives: A serialized entry dictionary or list of entry dictionaries. Each
+            entry may contain an ``archive`` dictionary and optional top-level data.
+
+    Returns:
+        A tuple containing the schema-typed Arrow table and a counter of serialized
+        archive keys that are not quantities or subsections in the resolved schemas.
+    """
+    rows, column_quantities, unhandled_keys = _archives_to_rows(archives)
+    column_names = sorted({column for row in rows for column in row})
+
+    arrays = []
+    for column_name in column_names:
+        values = [row.get(column_name) for row in rows]
+        quantity_def = column_quantities.get(column_name)
+        if quantity_def is None:
+            array = _infer_arrow_column(values, column_name)
+        else:
+            config = _quantity_to_arrow_column_config(quantity_def)
+            array = _normalize_arrow_column(
+                values,
+                config,
+                column_name,
+            )
+        arrays.append(array)
+
+    return pa.Table.from_arrays(arrays, names=column_names), unhandled_keys
 
 
 def _is_nested_type(dtype: pa.DataType) -> bool:
@@ -242,44 +456,6 @@ def _stringify_nested_columns(batch: pa.RecordBatch) -> pa.RecordBatch:
     )
 
 
-def _make_dataframe_arrow_compatible(df: pd.DataFrame) -> pd.DataFrame:
-    """Stringify object columns that cannot be written to Parquet as-is."""
-    normalized_df = df.copy()
-
-    for column_name in normalized_df.columns:
-        column = normalized_df[column_name]
-        if column.dtype != 'object':
-            continue
-
-        values = column.dropna().tolist()
-        if not values:
-            continue
-
-        try:
-            arrow_array = pa.array(values)
-            if pa.types.is_struct(arrow_array.type) and len(arrow_array.type) == 0:
-                # Parquet cannot write empty struct columns and PyArrow raises
-                # `ArrowNotImplementedError` in this case.
-                raise pa.ArrowNotImplementedError
-        except (
-            pa.ArrowInvalid,
-            pa.ArrowTypeError,
-            pa.ArrowNotImplementedError,
-            TypeError,
-            ValueError,
-        ):
-            normalized_df[column_name] = column.map(
-                lambda value: (
-                    json.dumps(value, sort_keys=True)
-                    if value is not None
-                    and not (isinstance(value, float) and pd.isna(value))
-                    else None
-                )
-            )
-
-    return normalized_df
-
-
 def write_parquet_file(path: str, data: list[dict]):
     """
     Writes a list of NOMAD entry dicts to a parquet file.
@@ -291,9 +467,7 @@ def write_parquet_file(path: str, data: list[dict]):
     if not path.endswith('parquet'):
         raise ValueError('Unsupported file format. Please use parquet.')
 
-    df = _make_dataframe_arrow_compatible(archives_to_dataframe(data))
-
-    table = pa.Table.from_pandas(df)
+    table, _ = archives_to_arrow_table(data)
     with pq.ParquetWriter(
         path,
         table.schema,

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -44,6 +44,8 @@ def _resolve_section_def(m_def: str | None) -> Section | None:
     """
     Get a section def (Section.m_def) for given `m_def` string by importing the
     associated section class.
+
+    TODO: Add support for resolving sections defined using YAML schema.
     """
     if not m_def:
         return None
@@ -62,15 +64,6 @@ def _resolve_section_def(m_def: str | None) -> Section | None:
         section_def = getattr(section, 'm_def', None)
         if isinstance(section_def, Section):
             return section_def
-
-    # # all_metainfo_packages()  # leads to circular imports
-    # package_name, section_name = m_def.rsplit('.', 1)
-    # package = Package.registry.get(package_name)
-    # if package is None:
-    #     return None
-
-    # definition = package.all_definitions.get(section_name)
-    # return definition if isinstance(definition, Section) else None
 
 
 def _quantity_to_arrow_column_config(quantity_def: Quantity) -> _ArrowColumnConfig:
@@ -457,8 +450,7 @@ def _stringify_nested_columns(batch: pa.RecordBatch) -> pa.RecordBatch:
 
 
 def write_parquet_file(path: str, data: list[dict]):
-    """
-    Writes a list of NOMAD entry dicts to a parquet file.
+    """Writes a list of NOMAD entry dicts to a parquet file.
 
     Args:
         path (str): The path where the file will be saved.
@@ -478,8 +470,7 @@ def write_parquet_file(path: str, data: list[dict]):
 
 
 def write_json_file(path: str, data: list[dict]):
-    """
-    Writes a list of NOMAD entry dicts to a JSON file.
+    """Writes a list of NOMAD entry dicts to a JSON file.
 
     Args:
         path (str): The path where the file will be saved.
@@ -488,15 +479,14 @@ def write_json_file(path: str, data: list[dict]):
     if not path.endswith('json'):
         raise ValueError('Unsupported file format. Please use json.')
 
-    with open(path, 'w') as f:
-        json.dump(data, f, indent=4)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
 
 
 def merge_files(
     input_file_paths: list[str], output_file_format: str, output_file_path: str
 ):
-    """
-    Merges multiple Parquet or JSON files into a single file.
+    """Merges multiple Parquet or JSON files into a single file.
 
     Args:
         input_file_paths (list[str]): List of file paths to be merged.

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -229,7 +229,9 @@ def _stringify_nested_columns(batch: pa.RecordBatch) -> pa.RecordBatch:
 
 
 def _make_dataframe_arrow_compatible(df: pd.DataFrame) -> pd.DataFrame:
-    """Stringify only object columns that Arrow cannot encode as a single type."""
+    """
+    Stringify object columns that cannot be written to Parquet as-is.
+    """
     normalized_df = df.copy()
 
     for column_name in normalized_df.columns:
@@ -242,8 +244,18 @@ def _make_dataframe_arrow_compatible(df: pd.DataFrame) -> pd.DataFrame:
             continue
 
         try:
-            pa.array(values)
-        except (pa.ArrowInvalid, pa.ArrowTypeError, TypeError, ValueError):
+            arrow_array = pa.array(values)
+            if pa.types.is_struct(arrow_array.type) and len(arrow_array.type) == 0:
+                # Parquet cannot write empty struct columns and PyArrow raises
+                # `ArrowNotImplementedError` in this case.
+                raise pa.ArrowNotImplementedError
+        except (
+            pa.ArrowInvalid,
+            pa.ArrowTypeError,
+            pa.ArrowNotImplementedError,
+            TypeError,
+            ValueError,
+        ):
             normalized_df[column_name] = column.map(
                 lambda value: (
                     json.dumps(value, sort_keys=True)

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -57,7 +57,10 @@ def _resolve_section_def(m_def: str | None) -> Section | None:
     package_name, section_name = m_def.rsplit('.', 1)
     try:
         module = importlib.import_module(package_name)
-    except ImportError:
+    except (ImportError, TypeError):
+        # skip section resolution when module is not found
+        # or when the module is not a valid Python module
+        # which happens entry uses a YAML schema
         module = None
 
     if module is not None:

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -68,7 +68,11 @@ def _resolve_section_def(m_def: str | None) -> Section | None:
 
 
 def _quantity_to_arrow_column_config(quantity_def: Quantity) -> _ArrowColumnConfig:
-    """Create an Arrow column config from a NOMAD quantity definition."""
+    """
+    Create an Arrow column config from a NOMAD quantity definition. Based on the quantity's type,
+    assigns the appropriate Arrow data type and stringify_json flag. If the quantity's shape is
+    available, integrates it into the Arrow data type.
+    """
     quantity_type = quantity_def.type
 
     if isinstance(quantity_type, Reference):
@@ -288,11 +292,23 @@ def _flatten_section(
 
 
 def _archives_to_rows(
-    archives: list[dict] | dict,
-) -> tuple[list[dict], dict[str, Quantity], Counter]:
+    archives: list[dict] | dict, logger=None
+) -> tuple[list[dict], dict[str, Quantity]]:
     """
     Flatten list of archive dicts into list of row dicts. Also returns column definition
     and a count of unhandled archive dict keys.
+
+    Shape of one archive dict corresponds to serialization of EntryArchive::
+        {
+            "entry_id": str,
+            "archive": {
+                "results": dict,
+                "metadata": dict,
+                "data": dict,
+                "processing_log": list[Any],
+                ...
+            },
+        }
     """
     if isinstance(archives, dict):
         archives = [archives]
@@ -307,6 +323,10 @@ def _archives_to_rows(
     for item in archives:
         if not isinstance(item, dict):
             raise ValueError('Input must be a dictionary (JSON object).')
+        if 'archive' not in item or 'entry_id' not in item:
+            raise ValueError('Archive key and entry_id key are required.')
+        if not isinstance(item['archive'], dict):
+            raise ValueError('Archive value must be a dictionary (JSON object).')
 
         context = _FlattenEntryContext(
             row={},
@@ -379,7 +399,7 @@ def archives_to_arrow_table(archives: list[dict] | dict, logger=None) -> pa.Tabl
     Returns:
         A schema-typed Arrow table.
     """
-    rows, column_quantities, unhandled_keys = _archives_to_rows(archives)
+    rows, columns_quantity_def = _archives_to_rows(archives, logger)
     column_names = sorted({column for row in rows for column in row})
 
     arrays = []

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -229,9 +229,7 @@ def _stringify_nested_columns(batch: pa.RecordBatch) -> pa.RecordBatch:
 
 
 def _make_dataframe_arrow_compatible(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    Stringify object columns that cannot be written to Parquet as-is.
-    """
+    """Stringify object columns that cannot be written to Parquet as-is."""
     normalized_df = df.copy()
 
     for column_name in normalized_df.columns:
@@ -269,7 +267,8 @@ def _make_dataframe_arrow_compatible(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def write_parquet_file(path: str, data: list[dict]):
-    """Writes a list of NOMAD entry dicts to a parquet file.
+    """
+    Writes a list of NOMAD entry dicts to a parquet file.
 
     Args:
         path (str): The path where the file will be saved.
@@ -291,7 +290,8 @@ def write_parquet_file(path: str, data: list[dict]):
 
 
 def write_json_file(path: str, data: list[dict]):
-    """Writes a list of NOMAD entry dicts to a JSON file.
+    """
+    Writes a list of NOMAD entry dicts to a JSON file.
 
     Args:
         path (str): The path where the file will be saved.
@@ -307,7 +307,8 @@ def write_json_file(path: str, data: list[dict]):
 def merge_files(
     input_file_paths: list[str], output_file_format: str, output_file_path: str
 ):
-    """Merges multiple Parquet or JSON files into a single file.
+    """
+    Merges multiple Parquet or JSON files into a single file.
 
     Args:
         input_file_paths (list[str]): List of file paths to be merged.

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -1,7 +1,10 @@
 import json
+import importlib
+from functools import lru_cache
 
 import json_stream
-from nomad.utils import dict_to_dataframe
+import pandas as pd
+from nomad.metainfo.metainfo import MSectionReference, Section
 
 try:
     import pyarrow as pa
@@ -12,6 +15,192 @@ except ImportError as e:
     raise ImportError(
         'pyarrow is required. Install with: pip install nomad-ml-workflows[cpu-action]'
     ) from e
+
+
+def _join_path(prefix: str, key: str) -> str:
+    return f'{prefix}.{key}' if prefix else key
+
+
+@lru_cache
+def _resolve_section_def(m_def: str | None) -> Section | None:
+    if not m_def:
+        return None
+
+    if '.' in m_def:
+        package_name, section_name = m_def.rsplit('.', 1)
+        try:
+            module = importlib.import_module(package_name)
+        except ImportError:
+            module = None
+
+        if module is not None:
+            section = getattr(module, section_name, None)
+            section_def = getattr(section, 'm_def', None)
+            if isinstance(section_def, Section):
+                return section_def
+
+    try:
+        resolved = MSectionReference().normalize(m_def).m_resolved()
+    except Exception:
+        return None
+
+    return resolved if isinstance(resolved, Section) else None
+
+
+def _flatten_generic(value, prefix: str, row: dict):
+    """Flatten generic nested data while keeping non-dict lists as leaf values."""
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _flatten_generic(item, _join_path(prefix, key), row)
+    elif isinstance(value, list):
+        if all(isinstance(item, dict) for item in value):
+            for index, item in enumerate(value):
+                _flatten_generic(item, _join_path(prefix, str(index)), row)
+        else:
+            row[prefix] = value
+    else:
+        row[prefix] = value
+
+
+def _store_leaf_value(row: dict, prefix: str, value):
+    """Store a value as one opaque DataFrame cell."""
+    row[prefix] = value
+
+
+def _flatten_archive_data_section(
+    section_data: dict, section_def: Section, prefix: str, row: dict
+):
+    """Flatten one NOMAD section by metainfo property boundaries.
+
+    This traversal is schema-guided:
+    - quantities are always opaque leaf values
+    - repeated and non-repeated subsections are the only recursive branches
+    - arrays, nested lists, and JSON payloads stored in quantities are never flattened
+
+    This keeps the DataFrame aligned with NOMAD metainfo semantics instead of the raw
+    JSON shape of serialized values.
+    """
+    handled_keys = set()
+
+    for quantity_name in section_def.all_quantities:
+        if quantity_name not in section_data:
+            continue
+        handled_keys.add(quantity_name)
+        _store_leaf_value(
+            row,
+            _join_path(prefix, quantity_name),
+            section_data[quantity_name],
+        )
+
+    for sub_section_name, sub_section_def in section_def.all_sub_sections.items():
+        if sub_section_name not in section_data:
+            continue
+
+        handled_keys.add(sub_section_name)
+        sub_section_value = section_data[sub_section_name]
+        sub_section_prefix = _join_path(prefix, sub_section_name)
+        child_section_def = sub_section_def.sub_section.m_resolved()
+
+        if sub_section_value is None:
+            _store_leaf_value(row, sub_section_prefix, None)
+            continue
+
+        if sub_section_def.repeats:
+            if not isinstance(sub_section_value, list):
+                _store_leaf_value(row, sub_section_prefix, sub_section_value)
+                continue
+
+            for index, item in enumerate(sub_section_value):
+                item_prefix = _join_path(sub_section_prefix, str(index))
+                if not isinstance(item, dict):
+                    _store_leaf_value(row, item_prefix, item)
+                    continue
+
+                item_section_def = _resolve_section_def(item.get('m_def'))
+                _flatten_archive_data_section(
+                    item,
+                    item_section_def or child_section_def,
+                    item_prefix,
+                    row,
+                )
+        else:
+            if not isinstance(sub_section_value, dict):
+                _store_leaf_value(row, sub_section_prefix, sub_section_value)
+                continue
+
+            item_section_def = _resolve_section_def(sub_section_value.get('m_def'))
+            _flatten_archive_data_section(
+                sub_section_value,
+                item_section_def or child_section_def,
+                sub_section_prefix,
+                row,
+            )
+
+    # Unknown keys are stored as opaque leaf values. This avoids accidental
+    # structural flattening when the serialized branch does not map cleanly to
+    # the resolved section definition.
+    for key, value in section_data.items():
+        if key in handled_keys:
+            continue
+        _store_leaf_value(row, _join_path(prefix, key), value)
+
+
+def archives_to_dataframe(archives: list[dict] | dict) -> pd.DataFrame:
+    """Convert serialized entries to a DataFrame with section-aware flattening.
+
+    The ``archive.data`` branch is flattened using NOMAD metainfo definitions:
+    recursion only follows declared subsections, while every quantity is treated as
+    an opaque leaf value. This means scalar values, arrays, nested lists, and JSON
+    payloads from quantities each end up in a single DataFrame cell.
+
+    Outside ``archive.data`` the function keeps the older generic flattening behavior,
+    because this first implementation only relies on schema guarantees for
+    ``archive.data``.
+    """
+    if isinstance(archives, dict):
+        archives = [archives]
+    elif not isinstance(archives, list):
+        raise ValueError(
+            'Input must be a dictionary (JSON object) or a list of dictionaries (JSON objects)'
+        )
+
+    rows = []
+    for item in archives:
+        if not isinstance(item, dict):
+            raise ValueError(
+                'Input must be a dictionary (JSON object) or a list of dictionaries (JSON objects)'
+            )
+
+        row = {}
+        for key, value in item.items():
+            prefix = key
+            if key != 'archive' or not isinstance(value, dict):
+                _flatten_generic(value, prefix, row)
+                continue
+
+            for archive_key, archive_value in value.items():
+                archive_prefix = _join_path(prefix, archive_key)
+
+                if archive_key != 'data' or not isinstance(archive_value, dict):
+                    _flatten_generic(archive_value, archive_prefix, row)
+                    continue
+
+                section_def = _resolve_section_def(archive_value.get('m_def'))
+                if section_def is None:
+                    _flatten_generic(archive_value, archive_prefix, row)
+                    continue
+
+                _flatten_archive_data_section(
+                    archive_value,
+                    section_def,
+                    archive_prefix,
+                    row,
+                )
+
+        rows.append(row)
+
+    result = pd.DataFrame(rows)
+    return result.reindex(sorted(result.columns), axis=1)
 
 
 def _is_nested_type(dtype: pa.DataType) -> bool:
@@ -52,6 +241,34 @@ def _stringify_nested_columns(batch: pa.RecordBatch) -> pa.RecordBatch:
     )
 
 
+def _make_dataframe_arrow_compatible(df: pd.DataFrame) -> pd.DataFrame:
+    """Stringify only object columns that Arrow cannot encode as a single type."""
+    normalized_df = df.copy()
+
+    for column_name in normalized_df.columns:
+        column = normalized_df[column_name]
+        if column.dtype != 'object':
+            continue
+
+        values = column.dropna().tolist()
+        if not values:
+            continue
+
+        try:
+            pa.array(values)
+        except (pa.ArrowInvalid, pa.ArrowTypeError, TypeError, ValueError):
+            normalized_df[column_name] = column.map(
+                lambda value: (
+                    json.dumps(value, sort_keys=True)
+                    if value is not None
+                    and not (isinstance(value, float) and pd.isna(value))
+                    else None
+                )
+            )
+
+    return normalized_df
+
+
 def write_parquet_file(path: str, data: list[dict]):
     """Writes a list of NOMAD entry dicts to a parquet file.
 
@@ -62,7 +279,7 @@ def write_parquet_file(path: str, data: list[dict]):
     if not path.endswith('parquet'):
         raise ValueError('Unsupported file format. Please use parquet.')
 
-    df = dict_to_dataframe(data)
+    df = _make_dataframe_arrow_compatible(archives_to_dataframe(data))
 
     table = pa.Table.from_pandas(df)
     with pq.ParquetWriter(

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -30,9 +30,10 @@ class _ArrowColumnConfig:
 
 
 @dataclass
-class _FlattenContext:
+class _FlattenEntryContext:
+    row: dict[str, str | int | float | bool | dict | list | None]
     columns_quantity_def: dict[str, Quantity]
-    unhandled_keys: Counter
+    unhandled_keys: list[str]
 
 
 def _join_path(prefix: str, key: str) -> str:
@@ -212,31 +213,16 @@ def _infer_arrow_column(values: list, column_name: str) -> pa.Array:
             ) from error
 
 
-def _flatten_generic(value, prefix: str, row: dict):
-    """Flatten generic nested data while keeping non-dict lists as leaf values."""
-    if isinstance(value, dict):
-        for key, item in value.items():
-            _flatten_generic(item, _join_path(prefix, key), row)
-    elif isinstance(value, list):
-        if all(isinstance(item, dict) for item in value):
-            for index, item in enumerate(value):
-                _flatten_generic(item, _join_path(prefix, str(index)), row)
-        else:
-            row[prefix] = value
-    else:
-        row[prefix] = value
-
-
 def _store_leaf_value(row: dict, col: str, value):
     """Store a value as one opaque DataFrame cell."""
     row[col] = value
+
 
 def _flatten_section(
     section_data: dict,
     section_def: Section,
     prefix: str,
-    row: dict,
-    context: _FlattenContext,
+    context: _FlattenEntryContext,
 ):
     """
     Flatten one serialized NOMAD section using its metainfo definition.
@@ -251,9 +237,9 @@ def _flatten_section(
         if quantity_name not in section_data:
             continue
         handled_keys.add(quantity_name)
-        col = _join_path(prefix, quantity_name) + '#' + section_def.qualified_name()
+        col = f'{_join_path(prefix, quantity_name)}#{section_def.qualified_name()}'
         context.columns_quantity_def.setdefault(col, quantity_def)
-        _store_leaf_value(row, col, section_data[quantity_name])
+        _store_leaf_value(context.row, col, section_data[quantity_name])
 
     for sub_section_name, sub_section_def in section_def.all_sub_sections.items():
         if sub_section_name not in section_data:
@@ -278,7 +264,6 @@ def _flatten_section(
                     item,
                     item_section_def or child_section_def,
                     item_prefix,
-                    row,
                     context,
                 )
         else:
@@ -290,16 +275,15 @@ def _flatten_section(
                 sub_section_value,
                 item_section_def or child_section_def,
                 sub_section_prefix,
-                row,
                 context,
             )
 
-    # Add the unhandled keys to the counter. These point to the obsolete data in the
+    # Add the unhandled keys to a list. These point to the obsolete data in the
     # archives that do not correspond to a subsection/quantity in the current schema
     for key, _ in section_data.items():
         if key not in [*handled_keys, *IGNORED_KEYS]:
-            context.unhandled_keys.update(
-                [f'{prefix}.{key}#{section_def.qualified_name()}']
+            context.unhandled_keys.append(
+                f'{prefix}.{key}#{section_def.qualified_name()}'
             )
 
 
@@ -319,32 +303,41 @@ def _archives_to_rows(
         )
 
     rows = []
-    context = _FlattenContext(columns_quantity_def={}, unhandled_keys=Counter())
+    columns_quantity_def: dict[str, Quantity] = {}
     for item in archives:
         if not isinstance(item, dict):
             raise ValueError('Input must be a dictionary (JSON object).')
 
-        row = {}
-        for key, value in item.items():
-            if key != 'archive':
-                # TODO: remove this support and require list[archive].
-                _flatten_generic(value, key, row)
-                continue
-
+        context = _FlattenEntryContext(
+            row={},
+            columns_quantity_def=columns_quantity_def,
+            unhandled_keys=[],
+        )
+        try:
             _flatten_section(
-                section_data=value,
+                section_data=item,
                 section_def=EntryArchive.m_def,
                 prefix='',
-                row=row,
                 context=context,
             )
+            rows.append(context.row)
+            columns_quantity_def.update(context.columns_quantity_def)
+            if context.unhandled_keys and logger:
+                logger.warning(
+                    'unhandled keys',
+                    entry_id=item['entry_id'],
+                    unhandled_keys=context.unhandled_keys,
+                )
+        except Exception as e:
+            if logger:
+                logger.error(
+                    'failed to flatten archive', entry_id=item['entry_id'], exc_info=e
+                )
 
-        rows.append(row)
-
-    return rows, context.columns_quantity_def, context.unhandled_keys
+    return rows, columns_quantity_def
 
 
-def archives_to_dataframe(archives: list[dict] | dict) -> tuple[pd.DataFrame, Counter]:
+def archives_to_dataframe(archives: list[dict] | dict, logger=None) -> pd.DataFrame:
     """
     Convert serialized NOMAD entries into a flattened pandas DataFrame.
 
@@ -358,20 +351,17 @@ def archives_to_dataframe(archives: list[dict] | dict) -> tuple[pd.DataFrame, Co
             entry may contain an ``archive`` dictionary and optional top-level data.
 
     Returns:
-        A tuple containing the flattened DataFrame and a counter of serialized archive
-        keys that are not quantities or subsections in the resolved NOMAD schemas.
+        A flattened DataFrame.
     """
-    rows, _, unhandled_keys = _archives_to_rows(archives)
+    rows, _ = _archives_to_rows(archives, logger=logger)
 
     df = pd.DataFrame(rows)
     sorted_df = df.reindex(sorted(df.columns), axis=1)
 
-    return sorted_df, unhandled_keys
+    return sorted_df
 
 
-def archives_to_arrow_table(
-    archives: list[dict] | dict,
-) -> tuple[pa.Table, Counter]:
+def archives_to_arrow_table(archives: list[dict] | dict, logger=None) -> pa.Table:
     """
     Convert serialized NOMAD entries into a schema-typed Arrow table.
 
@@ -387,8 +377,7 @@ def archives_to_arrow_table(
             entry may contain an ``archive`` dictionary and optional top-level data.
 
     Returns:
-        A tuple containing the schema-typed Arrow table and a counter of serialized
-        archive keys that are not quantities or subsections in the resolved schemas.
+        A schema-typed Arrow table.
     """
     rows, column_quantities, unhandled_keys = _archives_to_rows(archives)
     column_names = sorted({column for row in rows for column in row})
@@ -396,7 +385,7 @@ def archives_to_arrow_table(
     arrays = []
     for column_name in column_names:
         values = [row.get(column_name) for row in rows]
-        quantity_def = column_quantities.get(column_name)
+        quantity_def = columns_quantity_def.get(column_name)
         if quantity_def is None:
             array = _infer_arrow_column(values, column_name)
         else:
@@ -408,7 +397,7 @@ def archives_to_arrow_table(
             )
         arrays.append(array)
 
-    return pa.Table.from_arrays(arrays, names=column_names), unhandled_keys
+    return pa.Table.from_arrays(arrays, names=column_names)
 
 
 def _is_nested_type(dtype: pa.DataType) -> bool:
@@ -449,7 +438,7 @@ def _stringify_nested_columns(batch: pa.RecordBatch) -> pa.RecordBatch:
     )
 
 
-def write_parquet_file(path: str, data: list[dict]):
+def write_parquet_file(path: str, data: list[dict], logger=None):
     """Writes a list of NOMAD entry dicts to a parquet file.
 
     Args:
@@ -459,7 +448,7 @@ def write_parquet_file(path: str, data: list[dict]):
     if not path.endswith('parquet'):
         raise ValueError('Unsupported file format. Please use parquet.')
 
-    table, _ = archives_to_arrow_table(data)
+    table = archives_to_arrow_table(data, logger)
     with pq.ParquetWriter(
         path,
         table.schema,
@@ -469,7 +458,7 @@ def write_parquet_file(path: str, data: list[dict]):
         writer.write_table(table)
 
 
-def write_json_file(path: str, data: list[dict]):
+def write_json_file(path: str, data: list[dict], logger=None):
     """Writes a list of NOMAD entry dicts to a JSON file.
 
     Args:

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -336,9 +336,9 @@ def _archives_to_rows(
         if not isinstance(item, dict):
             raise ValueError('Input must be a dictionary (JSON object).')
         if 'archive' not in item or 'entry_id' not in item:
-            raise ValueError('Archive key and entry_id key are required.')
+            raise ValueError('archive and entry_id keys are required.')
         if not isinstance(item['archive'], dict):
-            raise ValueError('Archive value must be a dictionary (JSON object).')
+            raise ValueError('archive value must be a dictionary (JSON object).')
 
         context = _FlattenEntryContext(
             row={},

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -4,8 +4,10 @@ from functools import lru_cache
 
 import json_stream
 import pandas as pd
+from nomad.datamodel import all_metainfo_packages
 from nomad.datamodel.datamodel import EntryArchive
-from nomad.metainfo.metainfo import MSectionReference, Section
+from nomad.metainfo import Package
+from nomad.metainfo.metainfo import Section
 
 try:
     import pyarrow as pa
@@ -24,28 +26,36 @@ def _join_path(prefix: str, key: str) -> str:
 
 @lru_cache(maxsize=256)
 def _resolve_section_def(m_def: str | None) -> Section | None:
+    """
+    Get a section def (Section.m_def) for given `m_def` string by importing the
+    associated section class.
+    """
     if not m_def:
         return None
 
-    if '.' in m_def:
-        package_name, section_name = m_def.rsplit('.', 1)
-        try:
-            module = importlib.import_module(package_name)
-        except ImportError:
-            module = None
-
-        if module is not None:
-            section = getattr(module, section_name, None)
-            section_def = getattr(section, 'm_def', None)
-            if isinstance(section_def, Section):
-                return section_def
-
-    try:
-        resolved = MSectionReference().normalize(m_def).m_resolved()
-    except Exception:
+    if '.' not in m_def:
         return None
 
-    return resolved if isinstance(resolved, Section) else None
+    package_name, section_name = m_def.rsplit('.', 1)
+    try:
+        module = importlib.import_module(package_name)
+    except ImportError:
+        module = None
+
+    if module is not None:
+        section = getattr(module, section_name, None)
+        section_def = getattr(section, 'm_def', None)
+        if isinstance(section_def, Section):
+            return section_def
+
+    # # all_metainfo_packages()  # leads to circular imports
+    # package_name, section_name = m_def.rsplit('.', 1)
+    # package = Package.registry.get(package_name)
+    # if package is None:
+    #     return None
+
+    # definition = package.all_definitions.get(section_name)
+    # return definition if isinstance(definition, Section) else None
 
 
 def _flatten_generic(value, prefix: str, row: dict):

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -1,12 +1,11 @@
-import json
 import importlib
+import json
+from collections import Counter
 from functools import lru_cache
 
 import json_stream
 import pandas as pd
-from nomad.datamodel import all_metainfo_packages
 from nomad.datamodel.datamodel import EntryArchive
-from nomad.metainfo import Package
 from nomad.metainfo.metainfo import Section
 
 try:
@@ -19,6 +18,7 @@ except ImportError as e:
         'pyarrow is required. Install with: pip install nomad-ml-workflows[cpu-action]'
     ) from e
 
+IGNORED_KEYS = ['m_def', 'm_def_id', 'm_ref_archives']
 
 def _join_path(prefix: str, key: str) -> str:
     return f'{prefix}.{key}' if prefix else key
@@ -73,13 +73,16 @@ def _flatten_generic(value, prefix: str, row: dict):
         row[prefix] = value
 
 
-def _store_leaf_value(row: dict, prefix: str, value):
+def _store_leaf_value(row: dict, col: str, value):
     """Store a value as one opaque DataFrame cell."""
-    row[prefix] = value
-
+    row[col] = value
 
 def _flatten_section(
-    section_data: dict, section_def: Section, prefix: str, row: dict
+    section_data: dict,
+    section_def: Section,
+    prefix: str,
+    row: dict,
+    unhandled_keys: Counter,
 ):
     """
     Flatten one serialized NOMAD section using its metainfo definition.
@@ -94,11 +97,8 @@ def _flatten_section(
         if quantity_name not in section_data:
             continue
         handled_keys.add(quantity_name)
-        _store_leaf_value(
-            row,
-            _join_path(prefix, quantity_name),
-            section_data[quantity_name],
-        )
+        col = _join_path(prefix, quantity_name) + '#' + section_def.qualified_name()
+        _store_leaf_value(row, col, section_data[quantity_name])
 
     for sub_section_name, sub_section_def in section_def.all_sub_sections.items():
         if sub_section_name not in section_data:
@@ -106,12 +106,11 @@ def _flatten_section(
 
         handled_keys.add(sub_section_name)
         sub_section_value = section_data[sub_section_name]
+        if sub_section_value is None:
+            continue
+
         sub_section_prefix = _join_path(prefix, sub_section_name)
         child_section_def = sub_section_def.sub_section.m_resolved()
-
-        if sub_section_value is None:
-            _store_leaf_value(row, sub_section_prefix, None)
-            continue
 
         if sub_section_def.repeats:
             for index, item in enumerate(sub_section_value):
@@ -125,6 +124,7 @@ def _flatten_section(
                     item_section_def or child_section_def,
                     item_prefix,
                     row,
+                    unhandled_keys,
                 )
         else:
             # If m_def is available in the dict, get a section_def based on it.
@@ -136,18 +136,17 @@ def _flatten_section(
                 item_section_def or child_section_def,
                 sub_section_prefix,
                 row,
+                unhandled_keys,
             )
 
-    # Keep serialization-only fields such as m_def/m_def_id as leaf values instead of
-    # flattening them structurally. This preserves the "quantities opaque, only
-    # subsections recursive" rule for keys outside the resolved section definition.
-    for key, value in section_data.items():
-        if key in handled_keys:
-            continue
-        _store_leaf_value(row, _join_path(prefix, key), value)
+    # Add the unhandled keys to the counter. These point to the obsolete data in the
+    # archives that do not correspond to a subsection/quantity in the current schema
+    for key, _ in section_data.items():
+        if key not in [*handled_keys, *IGNORED_KEYS]:
+            unhandled_keys.update([f'{prefix}.{key}#{section_def.qualified_name()}'])
 
 
-def archives_to_dataframe(archives: list[dict] | dict) -> pd.DataFrame:
+def archives_to_dataframe(archives: list[dict] | dict) -> tuple[pd.DataFrame, Counter]:
     """
     Convert exported entries to a DataFrame.
 
@@ -177,27 +176,32 @@ def archives_to_dataframe(archives: list[dict] | dict) -> pd.DataFrame:
         )
 
     rows = []
+    unhandled_keys = Counter()
     for item in archives:
         if not isinstance(item, dict):
-            raise ValueError(
-                'Input must be a dictionary (JSON object).'
-            )
+            raise ValueError('Input must be a dictionary (JSON object).')
 
         row = {}
         for key, value in item.items():
             if key != 'archive':
-                _flatten_generic(value, key, row)
+                _flatten_generic(value, key, row)  #  TODO: remove this support, require list[archive]
                 continue
 
             # `archive` always starts from the fixed EntryArchive definition.
-            _flatten_section(value, EntryArchive.m_def, key, row)
+            _flatten_section(
+                section_data=value,
+                section_def=EntryArchive.m_def,
+                prefix='',
+                row=row,
+                unhandled_keys=unhandled_keys,
+            )
 
         rows.append(row)
 
     df = pd.DataFrame(rows)
     sorted_df = df.reindex(sorted(df.columns), axis=1)
 
-    return sorted_df
+    return sorted_df, unhandled_keys
 
 
 def _is_nested_type(dtype: pa.DataType) -> bool:

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -472,7 +472,7 @@ def write_parquet_file(path: str, data: list[dict], logger=None):
     if not path.endswith('parquet'):
         raise ValueError('Unsupported file format. Please use parquet.')
 
-    table = archives_to_arrow_table(data, logger)
+    table: pa.Table = archives_to_arrow_table(data, logger)
     with pq.ParquetWriter(
         path,
         table.schema,
@@ -480,6 +480,8 @@ def write_parquet_file(path: str, data: list[dict], logger=None):
         use_dictionary=True,
     ) as writer:
         writer.write_table(table)
+
+    return table.num_rows
 
 
 def write_json_file(path: str, data: list[dict], logger=None):
@@ -494,6 +496,8 @@ def write_json_file(path: str, data: list[dict], logger=None):
 
     with open(path, 'w', encoding='utf-8') as f:
         json.dump(data, f, indent=2)
+
+    return len(data)
 
 
 def merge_files(

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -22,7 +22,7 @@ def _join_path(prefix: str, key: str) -> str:
     return f'{prefix}.{key}' if prefix else key
 
 
-@lru_cache
+@lru_cache(maxsize=256)
 def _resolve_section_def(m_def: str | None) -> Section | None:
     if not m_def:
         return None
@@ -68,18 +68,15 @@ def _store_leaf_value(row: dict, prefix: str, value):
     row[prefix] = value
 
 
-def _flatten_archive_section(
+def _flatten_section(
     section_data: dict, section_def: Section, prefix: str, row: dict
 ):
-    """Flatten one NOMAD section by metainfo property boundaries.
+    """
+    Flatten one serialized NOMAD section using its metainfo definition.
 
-    This traversal is schema-guided:
-    - quantities are always opaque leaf values
-    - repeated and non-repeated subsections are the only recursive branches
-    - arrays, nested lists, and JSON payloads stored in quantities are never flattened
-
-    This keeps the DataFrame aligned with NOMAD metainfo semantics instead of the raw
-    JSON shape of serialized values.
+    The traversal only recurses through declared subsections. Every quantity is
+    treated as an opaque leaf value, regardless of whether it stores a scalar,
+    array, nested list, or JSON payload.
     """
     handled_keys = set()
 
@@ -109,25 +106,31 @@ def _flatten_archive_section(
         if sub_section_def.repeats:
             for index, item in enumerate(sub_section_value):
                 item_prefix = _join_path(sub_section_prefix, str(index))
+                # Of m_def is available in the dict, get a section_def based on it.
+                # Useful when available data uses a child section of the subsection's
+                # original section_def.
                 item_section_def = _resolve_section_def(item.get('m_def'))
-                _flatten_archive_section(
+                _flatten_section(
                     item,
                     item_section_def or child_section_def,
                     item_prefix,
                     row,
                 )
         else:
+            # If m_def is available in the dict, get a section_def based on it.
+            # Useful when available data uses a child section of the subsection's
+            # original section_def.
             item_section_def = _resolve_section_def(sub_section_value.get('m_def'))
-            _flatten_archive_section(
+            _flatten_section(
                 sub_section_value,
                 item_section_def or child_section_def,
                 sub_section_prefix,
                 row,
             )
 
-    # Unknown keys are stored as opaque leaf values. This avoids accidental
-    # structural flattening when the serialized branch does not map cleanly to
-    # the resolved section definition.
+    # Keep serialization-only fields such as m_def/m_def_id as leaf values instead of
+    # flattening them structurally. This preserves the "quantities opaque, only
+    # subsections recursive" rule for keys outside the resolved section definition.
     for key, value in section_data.items():
         if key in handled_keys:
             continue
@@ -135,67 +138,56 @@ def _flatten_archive_section(
 
 
 def archives_to_dataframe(archives: list[dict] | dict) -> pd.DataFrame:
-    """Convert serialized entries to a DataFrame with section-aware flattening.
+    """
+    Convert exported entries to a DataFrame.
 
-    If `archives` is a list, it should have the following structure:
+    Each input item is expected to be a dict containing a serialized `archive`
+    entry alongside optional top-level metadata fields. For example,
 
     ```python
-    [
-        {
-            param1: val,
-            param2: val,
-            ...
-            archive: {...}  # serialized EntryArchive instance 1
-        },
-        {
-            param1: val,
-            param2: val,
-            ...
-            archive: {...}  # serialized EntryArchive instance 2
-        },
-        ...
-    ]
+    {
+        entry_id: ...,
+        upload_id: ...,
+        archive: {...}  # serialized EntryArchive instance 1
+    }
     ```
 
-    Else if it is a dict, it should correspond to one of the list elements shown above.
-
-    The ``archive.data`` branch is flattened using NOMAD metainfo definitions:
-    recursion only follows declared subsections, while every quantity is treated as
-    an opaque leaf value. This means scalar values, arrays, nested lists, and JSON
-    payloads from quantities each end up in a single DataFrame cell.
-
-    Outside ``archive.data`` the function keeps the older generic flattening behavior,
-    because this first implementation only relies on schema guarantees for
-    ``archive.data``.
+    The `archive` value is flattened using `EntryArchive` metainfo definitions;
+    recursion only follows subsections and every quantity becomes one DataFrame cell.
+    This keeps the DataFrame aligned with NOMAD section boundaries across the whole
+    archive, including `archive.data` where plugin-provided `m_def` values are
+    used to resolve the concrete section definition.
     """
     if isinstance(archives, dict):
         archives = [archives]
     elif not isinstance(archives, list):
         raise ValueError(
-            'Input must be a dictionary (JSON object) or a list of dictionaries (JSON objects)'
+            'Input must be a dictionary (JSON object) or a list of dictionaries '
+            '(JSON objects)'
         )
 
     rows = []
     for item in archives:
         if not isinstance(item, dict):
             raise ValueError(
-                'Input must be a dictionary (JSON object) or a list of dictionaries (JSON objects)'
+                'Input must be a dictionary (JSON object).'
             )
 
         row = {}
         for key, value in item.items():
-            prefix = key
-
             if key != 'archive':
-                _flatten_generic(value, prefix, row)
+                _flatten_generic(value, key, row)
                 continue
 
-            _flatten_archive_section(value, EntryArchive.m_, prefix, row)
+            # `archive` always starts from the fixed EntryArchive definition.
+            _flatten_section(value, EntryArchive.m_def, key, row)
 
         rows.append(row)
 
-    result = pd.DataFrame(rows)
-    return result.reindex(sorted(result.columns), axis=1)
+    df = pd.DataFrame(rows)
+    sorted_df = df.reindex(sorted(df.columns), axis=1)
+
+    return sorted_df
 
 
 def _is_nested_type(dtype: pa.DataType) -> bool:

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 
 import json_stream
 import pandas as pd
+from nomad.datamodel.datamodel import EntryArchive
 from nomad.metainfo.metainfo import MSectionReference, Section
 
 try:
@@ -67,7 +68,7 @@ def _store_leaf_value(row: dict, prefix: str, value):
     row[prefix] = value
 
 
-def _flatten_archive_data_section(
+def _flatten_archive_section(
     section_data: dict, section_def: Section, prefix: str, row: dict
 ):
     """Flatten one NOMAD section by metainfo property boundaries.
@@ -106,30 +107,18 @@ def _flatten_archive_data_section(
             continue
 
         if sub_section_def.repeats:
-            if not isinstance(sub_section_value, list):
-                _store_leaf_value(row, sub_section_prefix, sub_section_value)
-                continue
-
             for index, item in enumerate(sub_section_value):
                 item_prefix = _join_path(sub_section_prefix, str(index))
-                if not isinstance(item, dict):
-                    _store_leaf_value(row, item_prefix, item)
-                    continue
-
                 item_section_def = _resolve_section_def(item.get('m_def'))
-                _flatten_archive_data_section(
+                _flatten_archive_section(
                     item,
                     item_section_def or child_section_def,
                     item_prefix,
                     row,
                 )
         else:
-            if not isinstance(sub_section_value, dict):
-                _store_leaf_value(row, sub_section_prefix, sub_section_value)
-                continue
-
             item_section_def = _resolve_section_def(sub_section_value.get('m_def'))
-            _flatten_archive_data_section(
+            _flatten_archive_section(
                 sub_section_value,
                 item_section_def or child_section_def,
                 sub_section_prefix,
@@ -147,6 +136,28 @@ def _flatten_archive_data_section(
 
 def archives_to_dataframe(archives: list[dict] | dict) -> pd.DataFrame:
     """Convert serialized entries to a DataFrame with section-aware flattening.
+
+    If `archives` is a list, it should have the following structure:
+
+    ```python
+    [
+        {
+            param1: val,
+            param2: val,
+            ...
+            archive: {...}  # serialized EntryArchive instance 1
+        },
+        {
+            param1: val,
+            param2: val,
+            ...
+            archive: {...}  # serialized EntryArchive instance 2
+        },
+        ...
+    ]
+    ```
+
+    Else if it is a dict, it should correspond to one of the list elements shown above.
 
     The ``archive.data`` branch is flattened using NOMAD metainfo definitions:
     recursion only follows declared subsections, while every quantity is treated as
@@ -174,28 +185,12 @@ def archives_to_dataframe(archives: list[dict] | dict) -> pd.DataFrame:
         row = {}
         for key, value in item.items():
             prefix = key
-            if key != 'archive' or not isinstance(value, dict):
+
+            if key != 'archive':
                 _flatten_generic(value, prefix, row)
                 continue
 
-            for archive_key, archive_value in value.items():
-                archive_prefix = _join_path(prefix, archive_key)
-
-                if archive_key != 'data' or not isinstance(archive_value, dict):
-                    _flatten_generic(archive_value, archive_prefix, row)
-                    continue
-
-                section_def = _resolve_section_def(archive_value.get('m_def'))
-                if section_def is None:
-                    _flatten_generic(archive_value, archive_prefix, row)
-                    continue
-
-                _flatten_archive_data_section(
-                    archive_value,
-                    section_def,
-                    archive_prefix,
-                    row,
-                )
+            _flatten_archive_section(value, EntryArchive.m_, prefix, row)
 
         rows.append(row)
 

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 
 import json_stream
 import pandas as pd
-from nomad.datamodel.datamodel import EntryArchive
+from nomad.datamodel.datamodel import EntryArchive, EntryData
 from nomad.metainfo import data_type as nomad_data_type
 from nomad.metainfo.metainfo import Quantity, Reference, Section
 
@@ -240,6 +240,13 @@ def _flatten_section(
     """
     handled_keys = set()
 
+    if prefix == 'data' and section_def == EntryData.m_def:
+        m_def = section_data.get('m_def')
+        if m_def != section_def.qualified_name():
+            raise AssertionError(
+                f'archive.data exists but schema definition "{m_def}" not found. Skipping entry.'
+            )
+
     for quantity_name, quantity_def in section_def.all_quantities.items():
         if quantity_name not in section_data:
             continue
@@ -324,6 +331,8 @@ def _archives_to_rows(
 
     rows = []
     columns_quantity_def: dict[str, Quantity] = {}
+    failed_to_flatten = []
+    unhandled_key_entry_ids: dict[str, set[str]] = {}
     for item in archives:
         if not isinstance(item, dict):
             raise ValueError('Input must be a dictionary (JSON object).')
@@ -346,17 +355,28 @@ def _archives_to_rows(
             )
             rows.append(context.row)
             columns_quantity_def.update(context.columns_quantity_def)
-            if context.unhandled_keys and logger:
-                logger.warning(
-                    'unhandled keys',
-                    entry_id=item['entry_id'],
-                    unhandled_keys=context.unhandled_keys,
-                )
+            for key in context.unhandled_keys:
+                unhandled_key_entry_ids.setdefault(key, set()).add(item['entry_id'])
         except Exception as e:
             if logger:
-                logger.error(
-                    'failed to flatten archive', entry_id=item['entry_id'], exc_info=e
+                logger.warning(
+                    f'failed to flatten archive (entry_id={item["entry_id"]})',
+                    exc_info=e,
                 )
+            failed_to_flatten.append(item['entry_id'])
+
+    if logger:
+        # cummulative logging
+        for key, entry_ids_set in unhandled_key_entry_ids.items():
+            entry_ids = list(entry_ids_set)
+            logger.warning(
+                f'unhandled key {key} (num_entries={len(entry_ids)})',
+                entry_ids=entry_ids,
+            )
+        if failed_to_flatten:
+            logger.warning(
+                f'failed to flatten archives (num_entries={len(failed_to_flatten)})',
+            )
 
     return rows, columns_quantity_def
 

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -1,6 +1,5 @@
 import importlib
 import json
-from collections import Counter
 from dataclasses import dataclass
 from functools import lru_cache
 

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -114,6 +114,7 @@ class ExportEntriesWorkflow:
             # (query, owner, required, batch_file_format) once.
             template_spi = SearchPageInput.from_user_input(
                 data,
+                page_num=0,
                 output_file_path='',  # placeholder, real paths are set per page below
                 max_entries_export_limit=config.max_entries_export_limit,
             )
@@ -145,15 +146,17 @@ class ExportEntriesWorkflow:
             # Build one SearchPageInput per page with the corresponding cursor and
             # export limit for that page
             search_page_inputs: list[SearchPageInput] = []
-            for page_index, cursor in enumerate(cursors_output.page_after_values):
-                entries_so_far = page_index * page_size
+            for page_iter, cursor in enumerate(cursors_output.page_after_values):
+                page_num = page_iter + 1
+                entries_so_far = page_iter * page_size
                 limit_for_page = min(
                     page_size, config.max_entries_export_limit - entries_so_far
                 )
                 spi = template_spi.model_copy(
                     update={
+                        'page_num': page_num,
                         'output_file_path': (
-                            f'{artifact_subdirectory}/{page_index + 1}'
+                            f'{artifact_subdirectory}/{page_num}'
                             f'.{template_spi.batch_file_format}'
                         ),
                         'max_entries_export_limit': limit_for_page,
@@ -181,11 +184,11 @@ class ExportEntriesWorkflow:
                             SearchPageWorkflow.run,
                             spi,
                             id=f'{workflow.info().workflow_id}-search-page-'
-                            f'{concurr_batch_start + i + 1}',
+                            f'{spi.page_num}',
                             parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
                             retry_policy=retry_policy,
                         )
-                        for i, spi in enumerate(concurr_batch_spis)
+                        for spi in concurr_batch_spis
                     ]
                 )
                 search_page_outputs.extend(concurr_batch_spos)

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -70,7 +70,7 @@ class SearchPageWorkflow:
 @workflow.defn
 class ExportEntriesWorkflow:
     @workflow.run
-    async def run(self, data: ExportEntriesUserInput) -> str:
+    async def run(self, data: ExportEntriesUserInput) -> ExportEntriesOutput:
         """
         Workflow to search entries and export them into a datafile in the specified
         upload.
@@ -141,7 +141,7 @@ class ExportEntriesWorkflow:
             )
             if cursors_output.num_pages == 0:
                 # No pages to export, return early with an empty dataset
-                return
+                return ExportEntriesOutput(exported_dir_path='', workflow_duration=0.0)
 
             # Build one SearchPageInput per page with the corresponding cursor and
             # export limit for that page

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -212,17 +212,18 @@ class ExportEntriesWorkflow:
                 for i, spo in enumerate(search_page_outputs)
                 if spo.num_entries_exported > 0
             ]
-            merged_file_path = await workflow.execute_activity(
-                merge_output_files,
-                MergeOutputFilesInput(
-                    artifact_subdirectory=artifact_subdirectory,
-                    output_file_format=data.output_settings.output_file_format,
-                    generated_file_paths=generated_file_paths,
-                ),
-                start_to_close_timeout=timedelta(hours=2),
-                retry_policy=retry_policy,
-            )
-            export_dataset_input.source_paths = [merged_file_path]
+            if generated_file_paths:
+                merged_file_path = await workflow.execute_activity(
+                    merge_output_files,
+                    MergeOutputFilesInput(
+                        artifact_subdirectory=artifact_subdirectory,
+                        output_file_format=data.output_settings.output_file_format,
+                        generated_file_paths=generated_file_paths,
+                    ),
+                    start_to_close_timeout=timedelta(hours=2),
+                    retry_policy=retry_policy,
+                )
+                export_dataset_input.source_paths = [merged_file_path]
 
         except Exception as e:
             # Capture error info to include in metadata


### PR DESCRIPTION
This PR improves NOMAD entry export by replacing generic DataFrame conversion with schema-aware archive processing.

- Flattens archives according to NOMAD metainfo quantities and subsections, including resolved `m_def` schemas and repeated sections.
- Constructs PyArrow tables directly from NOMAD quantity definitions, with safe casting, nested array support, and deterministic JSON fallbacks for complex or unsupported values.
- Adds contextual activity/page logging, structured archive-read errors, cumulative warnings for unhandled keys, and accurate exported-entry counts.
- Improves workflow robustness with stable page identifiers, typed outputs, and safe handling of empty export batches.