### PR TITLE
Use archive reading always; drop support for nomad.search

### DIFF
--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -34,7 +34,6 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
             export_dataset_to_upload,
             merge_output_files,
             read_archives,
-            search,
         )
         from nomad_ml_workflows.actions.export_entries.workflows import (
             ExportEntriesWorkflow,
@@ -48,7 +47,6 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
             activities=[
                 create_artifact_subdirectory,
                 collect_page_cursors,
-                search,
                 read_archives,
                 merge_output_files,
                 export_dataset_to_upload,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -20,7 +20,6 @@ from nomad_ml_workflows.actions.export_entries.models import (
     ExportDatasetInput,
     MergeOutputFilesInput,
     ReadArchivesInput,
-    SearchPageInput,
     SearchPageOutput,
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
@@ -53,66 +52,6 @@ async def create_artifact_subdirectory(data: CreateArtifactSubdirectoryInput) ->
     os.makedirs(subdir_path)
 
     return subdir_path
-
-
-@activity.defn
-async def search(data: SearchPageInput) -> SearchPageOutput:
-    """
-    Activity to perform NOMAD search based on the provided input data. The data indexed
-    in the ElasticSearch is read and written to a file in the specified format
-    (Parquet or JSON) in the artifacts directory.
-
-    No archives are read in this activity; non-indexed data like nd-arrays will not be
-    extrated.
-
-    Args:
-        data (SearchInput): Input data for the search activity.
-
-    Returns:
-        SearchOutput: Output data from the search activity.
-    """
-    info = activity.info()
-
-    activity_logger = logger.bind(
-        activity_type=info.activity_type,
-        search_page_num=data.page_num,
-    )
-
-    write_dataset_file = {
-        'parquet': write_parquet_file,
-        'json': write_json_file,
-    }.get(data.batch_file_format)
-    if write_dataset_file is None:
-        raise ValueError(f'Unsupported batch file format "{data.batch_file_format}". ')
-
-    start = datetime.now(timezone.utc).isoformat()
-    response = nomad_search(
-        user_id=data.user_id,
-        owner=data.owner,
-        query=data.query,
-        required=data.required,
-        pagination=data.pagination,
-        aggregations={},  # aggregations support can be added later
-    )
-    end = datetime.now(timezone.utc).isoformat()
-
-    # Limit the number of exported entries
-    entry_list = response.data[: data.max_entries_export_limit]
-
-    if entry_list:
-        num_entries_exported = write_dataset_file(
-            path=data.output_file_path, data=entry_list, logger=activity_logger
-        )
-    else:
-        num_entries_exported = 0
-
-    activity_logger.info(f'exported {num_entries_exported}/{len(entry_list)} entries')
-
-    return SearchPageOutput(
-        search_start_time=start,
-        search_end_time=end,
-        num_entries_exported=num_entries_exported,
-    )
 
 
 @activity.defn

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -30,11 +30,6 @@ class SearchSettings(BaseModel):
             'uiSchema': {'ui:widget': 'textarea', 'ui:options': {'rows': 5}}
         },
     )
-    read_archives: bool = Field(
-        False,
-        description='Read full archive data, including non-indexed fields such as '
-        'n-dim arrays. Disable to export only indexed fields faster.',
-    )
     required_include: list[str] = Field(
         [],
         description='List of fields to include in the search results. For example: '
@@ -95,11 +90,6 @@ class SearchPageInput(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
     query: Query = Field(..., description='Search query parameters.')
-    read_archives: bool = Field(
-        ...,
-        description='Read full archive data, including non-indexed fields such as '
-        'n-dim arrays.',
-    )
     required: Required = Field(
         ..., description='Required fields for filtering the search results.'
     )
@@ -166,7 +156,6 @@ class SearchPageInput(BaseModel):
             user_id=user_input.user_id,
             owner=user_input.search_settings.owner,
             query=query,
-            read_archives=user_input.search_settings.read_archives,
             required=required,
             pagination=pagination,
             batch_file_format=batch_file_format,
@@ -270,7 +259,6 @@ class ReadArchivesInput(SearchPageInput):
             user_id=spi.user_id,
             owner=spi.owner,
             query=spi.query,
-            read_archives=spi.read_archives,
             required=required,
             pagination=spi.pagination,
             batch_file_format=spi.batch_file_format,

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -16,7 +16,6 @@ with workflow.unsafe.imports_passed_through():
         export_dataset_to_upload,
         merge_output_files,
         read_archives,
-        search,
     )
     from nomad_ml_workflows.actions.export_entries.models import (
         CleanupArtifactsInput,
@@ -50,18 +49,10 @@ class SearchPageWorkflow:
         )
         retry_policy = RetryPolicy(maximum_attempts=1)
 
-        if data.read_archives:
-            rai = ReadArchivesInput.from_search_page_input(data)
-            return await workflow.execute_activity(
-                read_archives,
-                rai,
-                start_to_close_timeout=timedelta(seconds=config.search_batch_timeout),
-                retry_policy=retry_policy,
-            )
-
+        rai = ReadArchivesInput.from_search_page_input(data)
         return await workflow.execute_activity(
-            search,
-            data,
+            read_archives,
+            rai,
             start_to_close_timeout=timedelta(seconds=config.search_batch_timeout),
             retry_policy=retry_policy,
         )


### PR DESCRIPTION
- `nomad.search` only returns indexed fields. Even for standardized sections like `archive.results`, this can mean missing data.
- With archive reading capabilities now integrated, this is `nomad.search` is obsolete.
- Removing it makes the code simpler; no need to maintain two branches in the workflows.
- `nomad.search` can be faster than archive reading; but with the temporal handling and log sharing with the users, even if the archive reading workflows take longer, it's acceptable.