### PR TITLE
Refactor required directives handling

### DIFF
--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -19,7 +19,7 @@ from nomad_ml_workflows.actions.export_entries.models import (
     CreateArtifactSubdirectoryInput,
     ExportDatasetInput,
     MergeOutputFilesInput,
-    ReadArchivesInput,
+    SearchPageInput,
     SearchPageOutput,
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
@@ -129,7 +129,7 @@ async def collect_page_cursors(data: CollectCursorsInput) -> CollectCursorsOutpu
 
 
 @activity.defn
-async def read_archives(data: ReadArchivesInput) -> SearchPageOutput:
+async def read_archives(data: SearchPageInput) -> SearchPageOutput:
     """
     Activity to read archives of the searched entries. The required fields are read
     from the archives and written to a file in the specified format (Parquet or JSON)

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from nomad.app.v1.models.models import MetadataPagination, Query
 from pydantic import BaseModel, Field
@@ -10,6 +10,7 @@ OutputFileFormatLiteral = Literal['parquet', 'csv', 'json']
 
 
 class Include(BaseModel):
+    type: Literal['include'] = Field('include')
     path: str = Field(..., description='Archive paths to be included.')
     resolve_references: bool = Field(
         False,
@@ -18,12 +19,13 @@ class Include(BaseModel):
 
 
 class Exclude(BaseModel):
+    type: Literal['exclude'] = Field('exclude')
     path: str = Field(..., description='Archive paths to be excluded.')
 
 
-Required = Include
-# TODO: set "Required = Include | Exclude" once exclude directive is
-# supported in RequiredReader
+Required = Annotated[Include, Field(discriminator='type')]
+# TODO: set Required = Annotated[Include | Exclude, Field(discriminator='type')]
+# once exclude directive is supported in RequiredReader
 
 
 def _clean_field(field: str) -> str:
@@ -111,6 +113,13 @@ class SearchSettings(BaseModel):
         description='Required archive paths for filtering the search results. '
         'Paths can target quantities like "results.method.method_name" or '
         'sub-sections like "results".',
+        json_schema_extra={
+            'uiSchema': {
+                'items': {
+                    'type': {'ui:widget': 'hidden'},
+                },
+            },
+        },
     )
 
 

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -1,12 +1,36 @@
 import json
 from typing import Any, Literal
 
-from nomad.app.v1.models.models import MetadataPagination, MetadataRequired, Query
+from nomad.app.v1.models.models import MetadataPagination, Query
 from pydantic import BaseModel, Field
 
 OwnerLiteral = Literal['public', 'visible', 'shared', 'user', 'staging']
 BatchFileFormatLiteral = Literal['parquet', 'json']
 OutputFileFormatLiteral = Literal['parquet', 'csv', 'json']
+
+
+def _clean_field(field: str) -> str:
+    """
+    Removes trailing whitespaces and inverted commas
+    """
+    return field.strip().strip("'").strip('"')
+
+
+class Include(BaseModel):
+    path: str = Field(..., description='Archive paths to be included.')
+    resolve_references: bool = Field(
+        False,
+        description='Recursively resolve references for the included path.',
+    )
+
+
+class Exclude(BaseModel):
+    path: str = Field(..., description='Archive paths to be excluded.')
+
+
+Required = Include
+# TODO: set "Required = Include | Exclude" once exclude directive is
+# supported in RequiredReader
 
 
 class SearchSettings(BaseModel):
@@ -30,20 +54,11 @@ class SearchSettings(BaseModel):
             'uiSchema': {'ui:widget': 'textarea', 'ui:options': {'rows': 5}}
         },
     )
-    required_include: list[str] = Field(
-        [],
-        description='List of fields to include in the search results. For example: '
-        'results*, data.results*',
-    )
-    required_include_resolved: list[str] = Field(
-        [],
-        description='Paths to include, along with resolved referencs, in the exported '
-        'dataset. For example: results*, data.results*',
-    )
-    required_exclude: list[str] = Field(
-        [],
-        description='List of fields to exclude from the search results. For example: '
-        'results.method.method_name',
+    required: list[Required] | None = Field(
+        None,
+        description='Required archive paths for filtering the search results. '
+        'Paths can target quantities like "results.method.method_name" or '
+        'sub-sections like "results".',
     )
 
 
@@ -77,21 +92,14 @@ class CreateArtifactSubdirectoryInput(BaseModel):
     subdir_name: str = Field(..., description='Name of the subdirectory to be created.')
 
 
-class Required(MetadataRequired):
-    include_resolved: list[str] | None = Field(
-        None,
-        description='Quantities to include for each result. If the quantities include '
-        'references to other sections, the references will be resolved.'
-        'For example: results*, data.results*',
-    )
-
-
 class SearchPageInput(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
     query: Query = Field(..., description='Search query parameters.')
-    required: Required = Field(
-        ..., description='Required fields for filtering the search results.'
+    required: str | dict[str, Any] = Field(
+        '*',
+        description='Dictionary of required fields and directives compatible with '
+        '`nomad.archive.required.RequiredReader` class.',
     )
     pagination: MetadataPagination = Field(
         ..., description='Pagination settings for the search results.'
@@ -105,6 +113,89 @@ class SearchPageInput(BaseModel):
     )
     page_num: int = Field(..., description='Page number for the search results.')
 
+    @staticmethod
+    def build_archive_required(required: list[Required] | None) -> str | dict[str, Any]:
+        """Convert archive path requirements to a RequiredReader specification.
+
+        Includes select an archive path, optionally resolving all references below
+        it. Excludes remove a path from an included subtree. When only exclusions
+        are supplied, the rest of the archive is included by default.
+        """
+        if not required:
+            return '*'
+
+        directive_priority = {
+            'include': 1,
+            'include-resolved': 2,
+            'exclude': 3,
+        }  # 3 is highest priority
+        directives: dict[tuple[str, ...], str] = {}
+        has_include = False
+
+        for r in required:
+            path = _clean_field(r.path).rstrip('*')
+            path_parts = tuple(part for part in path.split('.') if part)
+            if not path_parts:
+                continue
+
+            if isinstance(r, Include):
+                has_include = True
+                directive = 'include-resolved' if r.resolve_references else 'include'
+            elif isinstance(r, Exclude):
+                directive = 'exclude'
+            else:
+                raise AssertionError(
+                    f'Only instances of Include or Exclude allowed, got "{r: type(r)}"'
+                )
+
+            directives[path_parts] = max(
+                directives.get(path_parts, directive),
+                directive,
+                key=directive_priority.__getitem__,
+            )  # if same path_parts has multiple directives, pick the higher priority one
+
+        if not directives:
+            return '*'
+
+        directive_key = object()
+        tree: dict[Any, Any] = {}
+        if not has_include:
+            tree[directive_key] = 'include'
+
+        for path_parts, directive in sorted(
+            directives.items(), key=lambda item: len(item[0])
+        ):
+            inherited_directive = next(
+                (
+                    directives[path_parts[:index]]
+                    for index in range(len(path_parts) - 1, 0, -1)
+                    if path_parts[:index] in directives
+                ),
+                None,
+            )
+            if directive == inherited_directive:
+                continue
+
+            node = tree
+            for part in path_parts:
+                node = node.setdefault(part, {})
+            node[directive_key] = directive
+
+        def _render(node: dict[Any, Any]) -> str | dict[str, Any]:
+            directive = node.get(directive_key)
+            children = {
+                key: _render(value)
+                for key, value in node.items()
+                if key is not directive_key
+            }
+            if directive is None:
+                return children
+            if not children:
+                return directive
+            return {'*': directive, **children}
+
+        return _render(tree)
+
     @classmethod
     def from_user_input(
         cls,
@@ -116,35 +207,13 @@ class SearchPageInput(BaseModel):
     ) -> 'SearchPageInput':
         """Convert from ExportEntriesUserInput to SearchPageInput"""
 
-        def _clean_field(field: str) -> str:
-            """
-            Removes trailing whitespaces and inverted commas
-            """
-            return field.strip().strip("'").strip('"')
-
         query = json.loads(
             _clean_field(user_input.search_settings.query).replace("'", '"')
         )
 
-        required = Required()
-        if user_input.search_settings.required_include:
-            include = [
-                _clean_field(field)
-                for field in user_input.search_settings.required_include
-            ]
-            required.include = include if include else None
-        if user_input.search_settings.required_include_resolved:
-            include_resolved = [
-                _clean_field(field)
-                for field in user_input.search_settings.required_include_resolved
-            ]
-            required.include_resolved = include_resolved if include_resolved else None
-        if user_input.search_settings.required_exclude:
-            exclude = [
-                _clean_field(field)
-                for field in user_input.search_settings.required_exclude
-            ]
-            required.exclude = exclude if exclude else None
+        archive_required = cls.build_archive_required(
+            user_input.search_settings.required
+        )
 
         pagination = MetadataPagination(page_size=user_input.search_settings.page_size)
 
@@ -156,115 +225,12 @@ class SearchPageInput(BaseModel):
             user_id=user_input.user_id,
             owner=user_input.search_settings.owner,
             query=query,
-            required=required,
+            required=archive_required,
             pagination=pagination,
             batch_file_format=batch_file_format,
             page_num=page_num,
             output_file_path=output_file_path,
             max_entries_export_limit=max_entries_export_limit,
-        )
-
-
-class ReadArchivesInput(SearchPageInput):
-    required: str | dict[str, Any] = Field(
-        '*',
-        description='Dictionary of required fields and directives compatible with '
-        '`nomad.archive.required.RequiredReader` class.',
-    )
-
-    @staticmethod
-    def build_archive_required(required: Required) -> str | dict:
-        """
-        Convert dot-separated required paths into a nested-dict structure with
-        directives on the leaf. Output can be used when instantiating the
-        `nomad.archive.required.RequiredReader` class.
-
-        Adds the following directives at the dict nodes:
-            - "include"             (for `required.include` list)
-            - "include-resolved"    (for `required.include_resolved` list)
-
-        Ignores the `required.exclude` list, since there is no support for
-        "exclude" directives.
-
-        If the required lists are empty, returns "*", meaning to include everything.
-
-        Examples:
-            - When required.include is:
-                []                         -> "*"
-                ["data"]                   -> {"data": "include"}
-                ["data.num_val"]           -> {"data": {"num_val": "include"}}
-                ["data.sub_sec"]           -> {"data": {"sub_sec": "include"}}
-                ["data.sub_sec*"]          -> {"data": {"sub_sec": "include"}}
-                                            (remove trailing *)
-                ["data", "data.sub_sec"]   -> {"data": "*"}
-                                            (parent wins)
-
-        For `required.include_resolved`, the directive changes to "include-resolved",
-        but the conversion follows the same logic.
-
-        When same fields are present in `required.include` and
-        `required.include_resolved`, "include-resolved" directive takes priority.
-        """
-        include = required.include or []
-        include_resolved = required.include_resolved or []
-
-        if not include and not include_resolved:
-            return '*'  # include everything
-
-        def _remove_wildcard(require_list: list) -> list:
-            return [el[:-1] if el.endswith('*') else el for el in require_list]
-
-        def _path_parts(path: str) -> list[str]:
-            return [part for part in path.split('.') if part]
-
-        def _add_include(
-            target: dict[str, Any], path: str, directive='include'
-        ) -> None:
-            node = target
-            parts = _path_parts(path)
-            for index, part in enumerate(parts):
-                is_leaf = index == len(parts) - 1
-                if is_leaf:
-                    node[part] = directive
-                    return
-                child = node.get(part)
-                if child == directive:
-                    return
-                if not isinstance(child, dict):
-                    child = {}
-                    node[part] = child
-                node = child
-
-        include = _remove_wildcard(include)
-        include_resolved = _remove_wildcard(include_resolved)
-
-        archive_required = {}
-        for path in include:
-            _add_include(archive_required, path, directive='include')
-        for path in include_resolved:
-            _add_include(archive_required, path, directive='include-resolved')
-
-        return archive_required
-
-    @classmethod
-    def from_search_page_input(
-        cls,
-        spi: SearchPageInput,
-    ) -> 'ReadArchivesInput':
-        """Convert from SearchPageInput to ReadArchivesInput"""
-
-        required = ReadArchivesInput.build_archive_required(spi.required)
-
-        return cls(
-            user_id=spi.user_id,
-            owner=spi.owner,
-            query=spi.query,
-            required=required,
-            pagination=spi.pagination,
-            batch_file_format=spi.batch_file_format,
-            page_num=spi.page_num,
-            output_file_path=spi.output_file_path,
-            max_entries_export_limit=spi.max_entries_export_limit,
         )
 
 

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -9,13 +9,6 @@ BatchFileFormatLiteral = Literal['parquet', 'json']
 OutputFileFormatLiteral = Literal['parquet', 'csv', 'json']
 
 
-def _clean_field(field: str) -> str:
-    """
-    Removes trailing whitespaces and inverted commas
-    """
-    return field.strip().strip("'").strip('"')
-
-
 class Include(BaseModel):
     path: str = Field(..., description='Archive paths to be included.')
     resolve_references: bool = Field(
@@ -31,6 +24,58 @@ class Exclude(BaseModel):
 Required = Include
 # TODO: set "Required = Include | Exclude" once exclude directive is
 # supported in RequiredReader
+
+
+def _clean_field(field: str) -> str:
+    """
+    Removes trailing whitespaces and inverted commas
+    """
+    return field.strip().strip("'").strip('"')
+
+
+_DIRECTIVE_PRIORITY = {'include': 1, 'include-resolved': 2, 'exclude': 3}
+
+
+def _path_and_directive(item: Include | Exclude) -> tuple[tuple[str, ...], str]:
+    """Normalize one user requirement."""
+    parts = tuple(
+        part for part in _clean_field(item.path).rstrip('*').split('.') if part
+    )
+    if isinstance(item, Include):
+        directive = 'include-resolved' if item.resolve_references else 'include'
+    elif isinstance(item, Exclude):
+        directive = 'exclude'
+    else:
+        raise TypeError(f'Unsupported requirement type: {type(item).__name__}')
+    return parts, directive
+
+
+def _add_required_path(
+    result: dict[str, Any], parts: tuple[str, ...], directive: str
+) -> None:
+    """Add one path, keeping the strongest directive at each level."""
+    node = result
+    for part in parts[:-1]:
+        current = node.get(part)
+        if isinstance(current, str):
+            if _DIRECTIVE_PRIORITY[current] >= _DIRECTIVE_PRIORITY[directive]:
+                return
+            current = {'*': current}
+            node[part] = current
+        node = node.setdefault(part, {})
+
+    leaf = parts[-1]
+    current = node.get(leaf)
+    if isinstance(current, dict):
+        current['*'] = max(
+            current.get('*', directive),
+            directive,
+            key=_DIRECTIVE_PRIORITY.__getitem__,
+        )
+    elif (
+        current is None or _DIRECTIVE_PRIORITY[directive] > _DIRECTIVE_PRIORITY[current]
+    ):
+        node[leaf] = directive
 
 
 class SearchSettings(BaseModel):
@@ -115,86 +160,52 @@ class SearchPageInput(BaseModel):
 
     @staticmethod
     def build_archive_required(required: list[Required] | None) -> str | dict[str, Any]:
-        """Convert archive path requirements to a RequiredReader specification.
-
-        Includes select an archive path, optionally resolving all references below
-        it. Excludes remove a path from an included subtree. When only exclusions
-        are supplied, the rest of the archive is included by default.
-        """
+        """Convert archive paths to a RequiredReader specification."""
         if not required:
             return '*'
 
-        directive_priority = {
-            'include': 1,
-            'include-resolved': 2,
-            'exclude': 3,
-        }  # 3 is highest priority
-        directives: dict[tuple[str, ...], str] = {}
-        has_include = False
-
-        for r in required:
-            path = _clean_field(r.path).rstrip('*')
-            path_parts = tuple(part for part in path.split('.') if part)
-            if not path_parts:
-                continue
-
-            if isinstance(r, Include):
-                has_include = True
-                directive = 'include-resolved' if r.resolve_references else 'include'
-            elif isinstance(r, Exclude):
-                directive = 'exclude'
-            else:
-                raise AssertionError(
-                    f'Only instances of Include or Exclude allowed, got "{r: type(r)}"'
-                )
-
-            directives[path_parts] = max(
-                directives.get(path_parts, directive),
-                directive,
-                key=directive_priority.__getitem__,
-            )  # if same path_parts has multiple directives, pick the higher priority one
-
-        if not directives:
+        paths = [_path_and_directive(item) for item in required]
+        paths = [(parts, directive) for parts, directive in paths if parts]
+        if not paths:
             return '*'
 
-        directive_key = object()
-        tree: dict[Any, Any] = {}
-        if not has_include:
-            tree[directive_key] = 'include'
+        # With only exclusions, start from the complete archive.
+        archive_required: dict[str, Any] = (
+            {}
+            if any(isinstance(item, Include) for item in required)
+            else {'*': 'include'}
+        )
 
-        for path_parts, directive in sorted(
-            directives.items(), key=lambda item: len(item[0])
-        ):
-            inherited_directive = next(
+        # Insert parents first so they absorb redundant child requirements.
+        for parts, directive in sorted(paths, key=lambda item: len(item[0])):
+            _add_required_path(archive_required, parts, directive)
+
+        # TODO: Remove this block once RequiredReader supports "*" keys.
+        # For now, a resolved child promotes its included parent.
+        included_paths = [parts for parts, value in paths if value == 'include']
+        resolved_paths = [
+            parts for parts, value in paths if value == 'include-resolved'
+        ]
+        for resolved_path in resolved_paths:
+            parent_path = min(
                 (
-                    directives[path_parts[:index]]
-                    for index in range(len(path_parts) - 1, 0, -1)
-                    if path_parts[:index] in directives
+                    path
+                    for path in included_paths
+                    if resolved_path[: len(path)] == path
+                    and len(resolved_path) > len(path)
                 ),
-                None,
+                key=len,
+                default=None,
             )
-            if directive == inherited_directive:
+            if parent_path is None:
                 continue
+            node = archive_required
+            for part in parent_path[:-1]:
+                node = node[part]
+            if isinstance(node.get(parent_path[-1]), dict):
+                node[parent_path[-1]] = 'include-resolved'
 
-            node = tree
-            for part in path_parts:
-                node = node.setdefault(part, {})
-            node[directive_key] = directive
-
-        def _render(node: dict[Any, Any]) -> str | dict[str, Any]:
-            directive = node.get(directive_key)
-            children = {
-                key: _render(value)
-                for key, value in node.items()
-                if key is not directive_key
-            }
-            if directive is None:
-                return children
-            if not children:
-                return directive
-            return {'*': directive, **children}
-
-        return _render(tree)
+        return archive_required
 
     @classmethod
     def from_user_input(

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -78,6 +78,13 @@ def _add_required_path(
         node[leaf] = directive
 
 
+def _contains_include(required: str | dict[str, Any]) -> bool:
+    """Return whether the final specification contains an include directive."""
+    if isinstance(required, str):
+        return required in {'include', 'include-resolved'}
+    return any(_contains_include(value) for value in required.values())
+
+
 class SearchSettings(BaseModel):
     owner: OwnerLiteral = Field(
         'visible', description='Owner of the entries to be searched.'
@@ -179,6 +186,10 @@ class SearchPageInput(BaseModel):
         # Insert parents first so they absorb redundant child requirements.
         for parts, directive in sorted(paths, key=lambda item: len(item[0])):
             _add_required_path(archive_required, parts, directive)
+
+        # Exclusions need a complete archive from which fields can be removed.
+        if not _contains_include(archive_required):
+            archive_required = {'*': 'include', **archive_required}
 
         # TODO: Remove this block once RequiredReader supports "*" keys.
         # For now, a resolved child promotes its included parent.

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -26,7 +26,6 @@ with workflow.unsafe.imports_passed_through():
         ExportEntriesOutput,
         ExportEntriesUserInput,
         MergeOutputFilesInput,
-        ReadArchivesInput,
         SearchPageInput,
         SearchPageOutput,
     )
@@ -49,10 +48,9 @@ class SearchPageWorkflow:
         )
         retry_policy = RetryPolicy(maximum_attempts=1)
 
-        rai = ReadArchivesInput.from_search_page_input(data)
         return await workflow.execute_activity(
             read_archives,
-            rai,
+            data,
             start_to_close_timeout=timedelta(seconds=config.search_batch_timeout),
             retry_policy=retry_policy,
         )

--- a/tests/actions/export_entries/test_models.py
+++ b/tests/actions/export_entries/test_models.py
@@ -69,7 +69,8 @@ def test_build_archive_required_exclude_over_include():
     ]
 
     assert SearchPageInput.build_archive_required(required) == {
-        'data': {'results': {'energy': 'exclude'}}
+        '*': 'include',
+        'data': {'results': {'energy': 'exclude'}},
     }
 
 
@@ -98,6 +99,19 @@ def test_build_archive_required_include_resolved_nested_exclude():
             '*': 'include-resolved',
             'results': {'energy': 'exclude'},
         }
+    }
+
+
+def test_build_archive_required_same_path_multiple_times():
+    required = [
+        Include(path='data.results.energy', resolve_references=True),
+        Include(path='data.results.energy', resolve_references=False),
+        Exclude(path='data.results.energy'),
+    ]
+
+    assert SearchPageInput.build_archive_required(required) == {
+        '*': 'include',
+        'data': {'results': {'energy': 'exclude'}},
     }
 
 

--- a/tests/actions/export_entries/test_models.py
+++ b/tests/actions/export_entries/test_models.py
@@ -1,46 +1,122 @@
-from nomad_ml_workflows.actions.export_entries.models import ReadArchivesInput, Required
+from nomad_ml_workflows.actions.export_entries.models import (
+    Exclude,
+    Include,
+    SearchPageInput,
+)
 
 
 def test_build_archive_required_returns_wildcard_for_empty_paths():
-    assert ReadArchivesInput.build_archive_required(Required()) == '*'
+    assert SearchPageInput.build_archive_required(None) == '*'
 
 
 def test_build_archive_required_builds_nested_include_tree():
-    required = Required(include=['data.results.energy'])
+    required = [Include(path='data.results.energy', resolve_references=False)]
 
-    assert ReadArchivesInput.build_archive_required(required) == {
+    assert SearchPageInput.build_archive_required(required) == {
         'data': {'results': {'energy': 'include'}}
     }
 
 
 def test_build_archive_required_prefers_parent_include():
-    required = Required(include=['data', 'data.results'])
+    required = [
+        Include(path='data', resolve_references=False),
+        Include(path='data.results', resolve_references=False),
+    ]
 
-    assert ReadArchivesInput.build_archive_required(required) == {'data': 'include'}
+    assert SearchPageInput.build_archive_required(required) == {'data': 'include'}
 
 
 def test_build_archive_required_strips_include_wildcard_suffix():
-    required = Required(include=['data.results*'])
+    required = [Include(path='data.results*', resolve_references=False)]
 
-    assert ReadArchivesInput.build_archive_required(required) == {
+    assert SearchPageInput.build_archive_required(required) == {
         'data': {'results': 'include'}
     }
 
 
 def test_build_archive_required_builds_include_resolved_directive():
-    required = Required(include_resolved=['data.results.energy'])
+    required = [Include(path='data.results.energy', resolve_references=True)]
 
-    assert ReadArchivesInput.build_archive_required(required) == {
+    assert SearchPageInput.build_archive_required(required) == {
         'data': {'results': {'energy': 'include-resolved'}}
     }
 
 
 def test_build_archive_required_prefers_include_resolved_for_same_path():
-    required = Required(
-        include=['data.results.energy'],
-        include_resolved=['data.results.energy'],
-    )
+    required = [
+        Include(path='data.results.energy', resolve_references=False),
+        Include(path='data.results.energy', resolve_references=True),
+    ]
 
-    assert ReadArchivesInput.build_archive_required(required) == {
+    assert SearchPageInput.build_archive_required(required) == {
         'data': {'results': {'energy': 'include-resolved'}}
+    }
+
+
+def test_build_archive_required_exclude():
+    required = [Exclude(path='data.results.energy')]
+
+    assert SearchPageInput.build_archive_required(required) == {
+        '*': 'include',
+        'data': {'results': {'energy': 'exclude'}},
+    }
+
+
+def test_build_archive_required_exclude_over_include():
+    required = [
+        Include(path='data.results.energy', resolve_references=False),
+        Exclude(path='data.results.energy'),
+    ]
+
+    assert SearchPageInput.build_archive_required(required) == {
+        'data': {'results': {'energy': 'exclude'}}
+    }
+
+
+def test_build_archive_required_include_nested_exclude():
+    required = [
+        Include(path='data', resolve_references=False),
+        Exclude(path='data.results.energy'),
+    ]
+
+    assert SearchPageInput.build_archive_required(required) == {
+        'data': {
+            '*': 'include',
+            'results': {'energy': 'exclude'},
+        }
+    }
+
+
+def test_build_archive_required_include_resolved_nested_exclude():
+    required = [
+        Include(path='data', resolve_references=True),
+        Exclude(path='data.results.energy'),
+    ]
+
+    assert SearchPageInput.build_archive_required(required) == {
+        'data': {
+            '*': 'include-resolved',
+            'results': {'energy': 'exclude'},
+        }
+    }
+
+
+def test_build_archive_required_prefers_include_resolved_for_whole_parent():
+    """
+    TODO: Remove once wildcard '*' as a key is supported in RequiredReader.
+
+    Ideally, this should give: {
+        'data': {
+            '*': 'include',
+            'results': {'energy': 'include-resolved'},
+        }
+    }
+    """
+    required = [
+        Include(path='data', resolve_references=False),
+        Include(path='data.results.energy', resolve_references=True),
+    ]
+
+    assert SearchPageInput.build_archive_required(required) == {
+        'data': 'include-resolved'
     }


### PR DESCRIPTION
- Replaces separate include/include-resolved inputs with a single Required model
- Builds nested `RequiredReader` specifications directly in `SearchPageInput`. 
  - `SearchPageInput.build_archive_required` implements a complete transformation into required dict with supported and to-be supported directives of `RequiredReader` 
  - Handles directive precedence, redundant child paths, exclusions, and exclusion-only exports.
- Avoids using non-implemented functionality of RequiredReader in a modular way.
  - `Exclude` model is not used in the user input
  - A nested `include-resolved` directive is changed into a parent `include-resolved` to avoid using wildcard key '*'
- Drops `ReadArchivesInput`
- Expands model tests to cover include, include-resolved, exclude, nesting, and conflicting directives.