### PR TITLE
Refactor archive reading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab>=1.4.3dev",
+    "nomad-lab>=1.4.3",
     "json-stream",
     "pydantic",
     "temporalio",
@@ -36,7 +36,7 @@ Repository = "https://github.com/FAIRmat-NFDI/nomad-ml-workflows"
 
 [project.optional-dependencies]
 dev = [
-    "nomad-lab[infrastructure]>=1.4.0",
+    "nomad-lab[infrastructure]>=1.4.3",
     "ruff",
     "pytest",
     "structlog",

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -29,35 +29,33 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
 
         from nomad_ml_workflows.actions.export_entries.activities import (
             cleanup_artifacts,
-            collect_page_cursors,
             create_artifact_subdirectory,
             export_dataset_to_upload,
-            merge_output_files,
-            read_archives,
-            rename_generated_file,
+            prepare_manifest,
+            read_archives_and_write_output_json,
+            read_archives_and_write_table_rows,
         )
         from nomad_ml_workflows.actions.export_entries.workflows import (
             ExportEntriesWorkflow,
-            SearchPageWorkflow,
+            ReadArchivesWorkflow,
         )
 
         return Action(
             task_queue=self.task_queue,
             workflow=ExportEntriesWorkflow,
-            child_workflows=[SearchPageWorkflow],
+            child_workflows=[ReadArchivesWorkflow],
             activities=[
                 create_artifact_subdirectory,
-                collect_page_cursors,
-                read_archives,
-                rename_generated_file,
-                merge_output_files,
+                prepare_manifest,
+                read_archives_and_write_output_json,
+                read_archives_and_write_table_rows,
                 export_dataset_to_upload,
                 cleanup_artifacts,
             ],
         )
 
 
-export_entries = ExportEntriesActionEntryPoint(
+export_entries = ExportEntriesActionEntryPoint(  # type: ignore
     name='Export Entries Action',
     description='An action to search entries and export them as a zip file in the '
     'specified upload.',

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -17,8 +17,8 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
         description='Timeout (in seconds) for the activity that reads '
         'and writes the output file.',
     )
-    max_write_buffered_bytes: int = Field(
-        default=1024 * 1024 * 32,  # 16 MB
+    max_write_buffer_size_bytes: int = Field(
+        default=1024 * 1024 * 32,  # 32 MB
         description='Maximum number of bytes to buffer before writing to the output '
         'tabular file. Increasing it can lead to higher memory usage but improved '
         'compression ratios.',

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -57,7 +57,6 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
 
 export_entries = ExportEntriesActionEntryPoint(  # type: ignore
     name='Export Entries Action',
-    description='An action to search entries and export them as a zip file in the '
-    'specified upload.',
+    description='An action to search entries and export them in the specified upload.',
     task_queue=TaskQueue.CPU,
 )

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -7,21 +7,21 @@ with workflow.unsafe.imports_passed_through():
 
 
 class ExportEntriesActionEntryPoint(ActionEntryPoint):
-    search_workflow_concurrency_limit: int = Field(
-        default=5,
-        description='Number of child search workflow instances to run concurrently in '
-        'the Export Entries action. Keep this low to avoid overwhelming the Temporal '
-        'server with too many concurrent activities.',
-    )
-    search_batch_timeout: int = Field(
-        default=7200,  # 2 hours
-        description='Timeout (in seconds) for each search batch in the Export Entries '
-        'action. Set this accordingly to time out longer searches.',
-    )
     max_entries_export_limit: int = Field(
         default=100000,
         description='Maximum number of entries that can be exported in a single '
         'Export Entries action.',
+    )
+    read_archives_timeout: int = Field(
+        default=7200,  # 2 hours
+        description='Timeout (in seconds) for the activity that reads '
+        'and writes the output file.',
+    )
+    max_write_buffered_bytes: int = Field(
+        default=1024 * 1024 * 32,  # 16 MB
+        description='Maximum number of bytes to buffer before writing to the output '
+        'tabular file. Increasing it can lead to higher memory usage but improved '
+        'compression ratios.',
     )
 
     def load(self):

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -18,7 +18,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
         'and writes the output file.',
     )
     max_write_buffer_size_bytes: int = Field(
-        default=1024 * 1024 * 32,  # 32 MB
+        default=1024 * 1024 * 4,  # 4 MB
         description='Maximum number of bytes to buffer before writing to the output '
         'tabular file. Increasing it can lead to higher memory usage but improved '
         'compression ratios.',

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -33,7 +33,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
             export_dataset_to_upload,
             prepare_manifest,
             read_archives_and_write_output_json,
-            read_archives_and_write_table_rows,
+            read_archives_and_write_output_tabular,
         )
         from nomad_ml_workflows.actions.export_entries.workflows import (
             ExportEntriesWorkflow,
@@ -48,7 +48,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
                 create_artifact_subdirectory,
                 prepare_manifest,
                 read_archives_and_write_output_json,
-                read_archives_and_write_table_rows,
+                read_archives_and_write_output_tabular,
                 export_dataset_to_upload,
                 cleanup_artifacts,
             ],

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -34,6 +34,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
             export_dataset_to_upload,
             merge_output_files,
             read_archives,
+            rename_generated_file,
         )
         from nomad_ml_workflows.actions.export_entries.workflows import (
             ExportEntriesWorkflow,
@@ -48,6 +49,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
                 create_artifact_subdirectory,
                 collect_page_cursors,
                 read_archives,
+                rename_generated_file,
                 merge_output_files,
                 export_dataset_to_upload,
                 cleanup_artifacts,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -70,7 +70,7 @@ def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
         data.num_entries_user_limit,
     )
     manifest: list = []
-    page_size = min(10000, max_num_entries_limit + 1)
+    page_size = min(10000, max_num_entries_limit)
     starttime = datetime.now(timezone.utc).isoformat()
     response = nomad_search(
         user_id=data.user_id,
@@ -79,6 +79,7 @@ def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
         required=MetadataRequired(include=['entry_id', 'upload_id']),  # type: ignore
         pagination=MetadataPagination(page_size=page_size),  # type: ignore
     )
+    num_entries_available = response.pagination.total
     while True:
         manifest.extend(
             [
@@ -89,6 +90,7 @@ def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
         if len(manifest) >= max_num_entries_limit:
             break
         if response.pagination.next_page_after_value is None:
+            # last page was already consumed
             break
         response = nomad_search(
             user_id=data.user_id,
@@ -102,19 +104,16 @@ def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
         )
     endtime = datetime.now(timezone.utc).isoformat()
 
-    if len(manifest) > max_num_entries_limit:
-        reached_max_entries_limit = True
-        manifest = manifest[:max_num_entries_limit]  #  Apply max limit
-    else:
-        reached_max_entries_limit = False
-
-    num_entries_available = len(manifest)
+    reached_max_entries_limit = num_entries_available > max_num_entries_limit
+    manifest = manifest[:max_num_entries_limit]
+    num_entries_selected = len(manifest)
     write_dicts_to_json(manifest, data.manifest_file_path)
 
     return PrepapeManifestOutput(
         search_start_time=starttime,
         search_end_time=endtime,
         num_entries_available=num_entries_available,
+        num_entries_selected=num_entries_selected,
         reached_max_entries_limit=reached_max_entries_limit,
     )
 

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -154,12 +154,13 @@ def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
         for entry in response.data
     ]
     manifest = manifest[: data.max_entries_export_limit]  #  Apply max limit
+    num_entries_exported = len(manifest)
     write_dicts_to_json(manifest, data.manifest_file_path)
 
     return PrepapeManifestOutput(
         search_start_time=starttime,
         search_end_time=endtime,
-        num_entries_available=len(manifest),
+        num_entries_available=num_entries_exported,
     )
 
 

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -23,9 +23,9 @@ from nomad_ml_workflows.actions.export_entries.models import (
     OutputFile,
     PrepapeManifestOutput,
     PrepareManifestInput,
-    ReadArchivesAndWriteOutputJsonInput,
-    ReadArchivesAndWriteTableRowsInput,
+    ReadArchivesWorkflowInput,
     RenameGeneratedFileInput,
+    TableRowsOutput,
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
     generate_archives,
@@ -165,44 +165,44 @@ def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
 
 @activity.defn
 def read_archives_and_write_output_json(
-    data: ReadArchivesAndWriteOutputJsonInput,
+    data: ReadArchivesWorkflowInput,
 ) -> OutputFile:
     """
     Reads the archives and writes the output JSON file.
     """
+    output_file_path = f'{data.artifact_subdirectory}/data.{data.output_file_format}'
+
     # load manifest
-    with open(data.manifest_path, encoding='utf-8') as f:
+    with open(data.manifest_file_path, encoding='utf-8') as f:
         manifest = [ManifestEntry(**entry) for entry in json.load(f)]
 
     info = activity.info()
     activity_logger = logger.bind(activity_type=info.activity_type)
 
     archives = generate_archives(manifest, data.required, data.user_id, activity_logger)
-    num_entries_exported = write_dicts_to_json(archives, data.output_file_path)
+    num_entries_exported = write_dicts_to_json(archives, output_file_path)
 
     return OutputFile(
-        file_path=data.output_file_path,
-        file_size=os.path.getsize(data.output_file_path),
+        file_path=output_file_path,
+        file_size=os.path.getsize(output_file_path),
         num_entries_exported=num_entries_exported,
     )
 
 
 @activity.defn
-async def read_archives_and_write_table_rows(data: ReadArchivesAndWriteTableRowsInput):
+async def read_archives_and_write_table_rows(
+    data: ReadArchivesWorkflowInput,
+) -> TableRowsOutput:
     """
-    Activity to read archives of the searched entries. The required fields are read
-    from the archives, converted to table rows, and written to a JSON file in the
-    artifact directory. At the same time, a list of required m_definitions is written to
-    another JSON file.
-
-    Args:
-        data (ReadArchivesAndWriteTableRowsInput): Input data for the search activity.
-
-    Returns:
-        SearchPageOutput: Output data from the search and read archives activity.
+    Reads archives and writes table rows and column quantity definitions to JSON files.
     """
+    table_rows_file_path = f'{data.artifact_subdirectory}/table_rows.tmp.json'
+    columns_quantity_def_file_path = (
+        f'{data.artifact_subdirectory}/columns_quantity_def.tmp.json'
+    )
+
     # load manifest
-    with open(data.manifest_path, encoding='utf-8') as f:
+    with open(data.manifest_file_path, encoding='utf-8') as f:
         manifest = [ManifestEntry(**entry) for entry in json.load(f)]
 
     info = activity.info()
@@ -213,10 +213,15 @@ async def read_archives_and_write_table_rows(data: ReadArchivesAndWriteTableRows
     )
 
     columns_quantity_def = write_table_rows_to_json(
-        rows_with_definitions, data.table_rows_file_path
+        rows_with_definitions, table_rows_file_path
     )
 
-    write_dicts_to_json([columns_quantity_def], data.columns_quantity_def_file_path)
+    write_dicts_to_json([columns_quantity_def], columns_quantity_def_file_path)
+
+    return TableRowsOutput(
+        table_rows_file_path=table_rows_file_path,
+        columns_quantity_def_file_path=columns_quantity_def_file_path,
+    )
 
 
 @activity.defn

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -193,13 +193,10 @@ def read_archives_and_write_output_tabular(
     Runs in an isolated process to ensure that memory is released after execution.
     """
 
-    if data.output_file_format not in {'parquet', 'csv'}:
-        raise ValueError(
-            f'Unsupported tabular output format: {data.output_file_format}'
-        )
-
     activity_type = activity.info().activity_type
 
+    # TODO: add the temporal context to the subprocess for logging
+    # and propagating failure and cancellation policy
     with ProcessPoolExecutor(
         max_workers=1,
         initializer=worker_process_initializer,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -5,7 +5,8 @@ import zipfile
 from datetime import datetime, timezone
 
 from nomad.actions.manager import action_artifacts_dir
-from nomad.app.v1.models.models import MetadataRequired
+from nomad.app.v1.models.models import MetadataPagination, MetadataRequired
+from nomad.config import config as nomad_config
 from nomad.files import StagingUploadFiles
 from nomad.search import search as nomad_search
 from nomad.uploads import get_upload_files
@@ -30,6 +31,9 @@ from nomad_ml_workflows.actions.export_entries.utils import (
     write_table_rows_to_tabular_file,
 )
 
+config = nomad_config.get_plugin_entry_point(
+    'nomad_ml_workflows.actions:export_entries'
+)
 logger = get_logger(__name__)
 
 
@@ -58,14 +62,17 @@ async def create_artifact_subdirectory(data: CreateArtifactSubdirectoryInput) ->
 
 @activity.defn
 def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
-
+    max_num_entries_limit = min(
+        config.max_entries_export_limit,  # type: ignore
+        data.num_entries_user_limit,
+    )
     starttime = datetime.now(timezone.utc).isoformat()
     response = nomad_search(
         user_id=data.user_id,
         owner=data.owner,
         query=data.query,
         required=MetadataRequired(include=['entry_id', 'upload_id']),  # type: ignore
-        pagination=data.pagination,
+        pagination=MetadataPagination(page_size=max_num_entries_limit + 1),  # type: ignore
     )
     endtime = datetime.now(timezone.utc).isoformat()
 
@@ -73,14 +80,20 @@ def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
         {'entry_id': entry['entry_id'], 'upload_id': entry['upload_id']}
         for entry in response.data
     ]
-    manifest = manifest[: data.max_entries_export_limit]  #  Apply max limit
-    num_entries_exported = len(manifest)
+    if len(manifest) > max_num_entries_limit:
+        reached_max_entries_limit = True
+        manifest = manifest[:max_num_entries_limit]  #  Apply max limit
+    else:
+        reached_max_entries_limit = False
+
+    num_entries_available = len(manifest)
     write_dicts_to_json(manifest, data.manifest_file_path)
 
     return PrepapeManifestOutput(
         search_start_time=starttime,
         search_end_time=endtime,
-        num_entries_available=num_entries_exported,
+        num_entries_available=num_entries_available,
+        reached_max_entries_limit=reached_max_entries_limit,
     )
 
 
@@ -143,7 +156,7 @@ async def read_archives_and_write_output_tabular(
         table_rows_file_path,
         output_file_path,
         columns_quantity_def,
-        max_buffer_bytes=2 * 1024 * 1024,
+        max_buffer_bytes=config.max_write_buffered_bytes,  # type: ignore
         logger=activity_logger,
     )
 

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -31,7 +31,7 @@ from nomad_ml_workflows.actions.export_entries.utils import (
     generate_table_rows,
     merge_files,
     write_dicts_to_json,
-    write_table_rows_to_json,
+    write_table_rows_to_ndjson,
     write_table_rows_to_tabular_file,
 )
 
@@ -201,7 +201,7 @@ async def read_archives_and_write_output_tabular(
             f'Unsupported tabular output format: {data.output_file_format}'
         )
 
-    table_rows_file_path = f'{data.artifact_subdirectory}/table_rows.tmp.json'
+    table_rows_file_path = f'{data.artifact_subdirectory}/table_rows.tmp.ndjson'
     output_file_path = f'{data.artifact_subdirectory}/data.{data.output_file_format}'
 
     # load manifest
@@ -215,7 +215,7 @@ async def read_archives_and_write_output_tabular(
         manifest, data.required, data.user_id, activity_logger
     )
 
-    columns_quantity_def = write_table_rows_to_json(
+    columns_quantity_def = write_table_rows_to_ndjson(
         rows_with_columns_quantity_def, table_rows_file_path
     )
     num_entries_exported = write_table_rows_to_tabular_file(

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -29,6 +29,7 @@ from nomad_ml_workflows.actions.export_entries.models import (
 from nomad_ml_workflows.actions.export_entries.utils import (
     generate_archives,
     generate_table_rows,
+    worker_process_initializer,
     write_dicts_to_json,
     write_table_rows_to_ndjson,
     write_table_rows_to_tabular_file,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -69,20 +69,39 @@ def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
         config.max_entries_export_limit,  # type: ignore
         data.num_entries_user_limit,
     )
+    manifest: list = []
+    page_size = min(10000, max_num_entries_limit + 1)
     starttime = datetime.now(timezone.utc).isoformat()
     response = nomad_search(
         user_id=data.user_id,
         owner=data.owner,
         query=data.query,
         required=MetadataRequired(include=['entry_id', 'upload_id']),  # type: ignore
-        pagination=MetadataPagination(page_size=max_num_entries_limit + 1),  # type: ignore
+        pagination=MetadataPagination(page_size=page_size),  # type: ignore
     )
+    while True:
+        manifest.extend(
+            [
+                {'entry_id': entry['entry_id'], 'upload_id': entry['upload_id']}
+                for entry in response.data
+            ]
+        )
+        if len(manifest) >= max_num_entries_limit:
+            break
+        if response.pagination.next_page_after_value is None:
+            break
+        response = nomad_search(
+            user_id=data.user_id,
+            owner=data.owner,
+            query=data.query,
+            required=MetadataRequired(include=['entry_id', 'upload_id']),  # type: ignore
+            pagination=MetadataPagination(
+                page_size=page_size,
+                page_after_value=response.pagination.next_page_after_value,
+            ),  # type: ignore
+        )
     endtime = datetime.now(timezone.utc).isoformat()
 
-    manifest: list = [
-        {'entry_id': entry['entry_id'], 'upload_id': entry['upload_id']}
-        for entry in response.data
-    ]
     if len(manifest) > max_num_entries_limit:
         reached_max_entries_limit = True
         manifest = manifest[:max_num_entries_limit]  #  Apply max limit

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -7,6 +7,7 @@ from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime, timezone
 
 from nomad.actions.manager import action_artifacts_dir
+from nomad.actions.workers.utils import worker_process_initializer
 from nomad.app.v1.models.models import MetadataPagination, MetadataRequired
 from nomad.config import config as nomad_config
 from nomad.files import StagingUploadFiles
@@ -182,7 +183,9 @@ def read_archives_and_write_output_tabular(
     activity_type = activity.info().activity_type
 
     with ProcessPoolExecutor(
-        max_workers=1, mp_context=multiprocessing.get_context('spawn')
+        max_workers=1,
+        initializer=worker_process_initializer,
+        mp_context=multiprocessing.get_context('spawn'),
     ) as executor:
         future = executor.submit(
             _read_archives_and_write_output_tabular,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -1,7 +1,9 @@
 import json
+import multiprocessing
 import os
 import shutil
 import zipfile
+from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime, timezone
 
 from nomad.actions.manager import action_artifacts_dir
@@ -123,17 +125,10 @@ def read_archives_and_write_output_json(
     )
 
 
-@activity.defn
-async def read_archives_and_write_output_tabular(
-    data: ReadArchivesWorkflowInput,
+def _read_archives_and_write_output_tabular(
+    data: ReadArchivesWorkflowInput, activity_type: str
 ) -> OutputFile:
-    """
-    Reads archives and streams flattened table rows to Parquet or CSV.
-    """
-    if data.output_file_format not in {'parquet', 'csv'}:
-        raise ValueError(
-            f'Unsupported tabular output format: {data.output_file_format}'
-        )
+    activity_logger = logger.bind(activity_type=activity_type)
 
     table_rows_file_path = f'{data.artifact_subdirectory}/table_rows.tmp.ndjson'
     output_file_path = f'{data.artifact_subdirectory}/data.{data.output_file_format}'
@@ -142,16 +137,15 @@ async def read_archives_and_write_output_tabular(
     with open(data.manifest_file_path, encoding='utf-8') as f:
         manifest = [ManifestEntry(**entry) for entry in json.load(f)]
 
-    info = activity.info()
-    activity_logger = logger.bind(activity_type=info.activity_type)
-
     rows_with_columns_quantity_def = generate_table_rows(
         manifest, data.required, data.user_id, activity_logger
     )
 
+    activity_logger.info('Reading archives and building the schema...')
     columns_quantity_def = write_table_rows_to_ndjson(
         rows_with_columns_quantity_def, table_rows_file_path
     )
+    activity_logger.info('Writing table rows to tabular file...')
     num_entries_exported = write_table_rows_to_tabular_file(
         table_rows_file_path,
         output_file_path,
@@ -159,12 +153,43 @@ async def read_archives_and_write_output_tabular(
         max_buffer_bytes=config.max_write_buffer_size_bytes,  # type: ignore
         logger=activity_logger,
     )
+    activity_logger.info(
+        f'{num_entries_exported} table rows written to '
+        f'"data.{data.output_file_format}" file.'
+    )
 
     return OutputFile(
         file_path=output_file_path,
         file_size=os.path.getsize(output_file_path),
         num_entries_exported=num_entries_exported,
     )
+
+
+@activity.defn
+def read_archives_and_write_output_tabular(
+    data: ReadArchivesWorkflowInput,
+) -> OutputFile:
+    """
+    Reads archives and streams flattened table rows to Parquet or CSV.
+    Runs in an isolated process to ensure that memory is released after execution.
+    """
+
+    if data.output_file_format not in {'parquet', 'csv'}:
+        raise ValueError(
+            f'Unsupported tabular output format: {data.output_file_format}'
+        )
+
+    activity_type = activity.info().activity_type
+
+    with ProcessPoolExecutor(
+        max_workers=1, mp_context=multiprocessing.get_context('spawn')
+    ) as executor:
+        future = executor.submit(
+            _read_archives_and_write_output_tabular,
+            data,
+            activity_type,
+        )
+        return future.result()
 
 
 @activity.defn

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -21,8 +21,8 @@ from nomad_ml_workflows.actions.export_entries.models import (
     ExportDatasetInput,
     ManifestEntry,
     OutputFile,
-    PrepapeManifestOutput,
     PrepareManifestInput,
+    PrepareManifestOutput,
     ReadArchivesWorkflowInput,
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
@@ -64,7 +64,7 @@ async def create_artifact_subdirectory(data: CreateArtifactSubdirectoryInput) ->
 
 
 @activity.defn
-def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
+def prepare_manifest(data: PrepareManifestInput) -> PrepareManifestOutput:
     max_num_entries_limit = min(
         config.max_entries_export_limit,  # type: ignore
         data.num_entries_user_limit,
@@ -109,7 +109,7 @@ def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
     num_entries_selected = len(manifest)
     write_dicts_to_json(manifest, data.manifest_file_path)
 
-    return PrepapeManifestOutput(
+    return PrepareManifestOutput(
         search_start_time=starttime,
         search_end_time=endtime,
         num_entries_available=num_entries_available,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -27,7 +27,6 @@ from nomad_ml_workflows.actions.export_entries.models import (
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
     generate_archives,
-    generate_table_rows,
     worker_process_initializer,
     write_dicts_to_json,
     write_table_rows_to_ndjson,
@@ -156,13 +155,9 @@ def _read_archives_and_write_output_tabular(
     with open(data.manifest_file_path, encoding='utf-8') as f:
         manifest = [ManifestEntry(**entry) for entry in json.load(f)]
 
-    rows_with_columns_quantity_def = generate_table_rows(
-        manifest, data.required, data.user_id, activity_logger
-    )
-
     activity_logger.info('Reading archives and building the schema...')
     columns_quantity_def = write_table_rows_to_ndjson(
-        rows_with_columns_quantity_def, table_rows_file_path
+        manifest, data.required, data.user_id, table_rows_file_path, activity_logger
     )
     activity_logger.info('Writing table rows to tabular file...')
     num_entries_exported = write_table_rows_to_tabular_file(

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -7,7 +7,6 @@ from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime, timezone
 
 from nomad.actions.manager import action_artifacts_dir
-from nomad.actions.workers.utils import worker_process_initializer
 from nomad.app.v1.models.models import MetadataPagination, MetadataRequired
 from nomad.config import config as nomad_config
 from nomad.files import StagingUploadFiles

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -25,15 +25,14 @@ from nomad_ml_workflows.actions.export_entries.models import (
     PrepareManifestInput,
     ReadArchivesWorkflowInput,
     RenameGeneratedFileInput,
-    TableRowsOutput,
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
     generate_archives,
     generate_table_rows,
     merge_files,
     write_dicts_to_json,
-    write_parquet_file,
     write_table_rows_to_json,
+    write_table_rows_to_tabular_file,
 )
 
 logger = get_logger(__name__)
@@ -191,16 +190,19 @@ def read_archives_and_write_output_json(
 
 
 @activity.defn
-async def read_archives_and_write_table_rows(
+async def read_archives_and_write_output_tabular(
     data: ReadArchivesWorkflowInput,
-) -> TableRowsOutput:
+) -> OutputFile:
     """
-    Reads archives and writes table rows and column quantity definitions to JSON files.
+    Reads archives and streams flattened table rows to Parquet or CSV.
     """
+    if data.output_file_format not in {'parquet', 'csv'}:
+        raise ValueError(
+            f'Unsupported tabular output format: {data.output_file_format}'
+        )
+
     table_rows_file_path = f'{data.artifact_subdirectory}/table_rows.tmp.json'
-    columns_quantity_def_file_path = (
-        f'{data.artifact_subdirectory}/columns_quantity_def.tmp.json'
-    )
+    output_file_path = f'{data.artifact_subdirectory}/data.{data.output_file_format}'
 
     # load manifest
     with open(data.manifest_file_path, encoding='utf-8') as f:
@@ -209,52 +211,25 @@ async def read_archives_and_write_table_rows(
     info = activity.info()
     activity_logger = logger.bind(activity_type=info.activity_type)
 
-    rows_with_definitions = generate_table_rows(
+    rows_with_columns_quantity_def = generate_table_rows(
         manifest, data.required, data.user_id, activity_logger
     )
 
     columns_quantity_def = write_table_rows_to_json(
-        rows_with_definitions, table_rows_file_path
+        rows_with_columns_quantity_def, table_rows_file_path
     )
-
-    write_dicts_to_json([columns_quantity_def], columns_quantity_def_file_path)
-
-    return TableRowsOutput(
-        table_rows_file_path=table_rows_file_path,
-        columns_quantity_def_file_path=columns_quantity_def_file_path,
-    )
-
-
-@activity.defn
-def write_output_file_tabular(
-    data: ReadArchivesAndWriteTableRowsInput, entry_archives: list[dict]
-) -> OutputFile:
-    """
-    Writes the output file based on the batch file format.
-    """
-    write_dataset_file = {
-        'parquet': write_parquet_file,
-        # 'csv': write_csv_file,
-    }.get(data.batch_file_format)
-    if write_dataset_file is None:
-        raise ValueError(f'Unsupported batch file format "{data.batch_file_format}". ')
-
-    if entry_archives:
-        num_entries_exported = write_dataset_file(
-            path=data.output_file_path,
-            data=entry_archives,
-            logger=activity_logger,
-        )
-    else:
-        num_entries_exported = 0
-
-    activity_logger.info(
-        f'exported {num_entries_exported}/{len(entry_archives)} entries'
+    num_entries_exported = write_table_rows_to_tabular_file(
+        table_rows_file_path,
+        output_file_path,
+        columns_quantity_def,
+        max_buffer_bytes=2 * 1024 * 1024,
+        logger=activity_logger,
     )
 
     return OutputFile(
-        file_path=data.output_file_path,
-        file_size=os.path.getsize(data.output_file_path),
+        file_path=output_file_path,
+        file_size=os.path.getsize(output_file_path),
+        num_entries_exported=num_entries_exported,
     )
 
 

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -19,6 +19,7 @@ from nomad_ml_workflows.actions.export_entries.models import (
     CreateArtifactSubdirectoryInput,
     ExportDatasetInput,
     MergeOutputFilesInput,
+    RenameGeneratedFileInput,
     SearchPageInput,
     SearchPageOutput,
 )
@@ -223,6 +224,15 @@ async def read_archives(data: SearchPageInput) -> SearchPageOutput:
 
 
 @activity.defn
+def rename_generated_file(data: RenameGeneratedFileInput) -> str | None:
+    target_file_path = os.path.join(
+        data.artifact_subdirectory, 'data.' + data.output_file_format
+    )
+    os.rename(data.generated_file_path, target_file_path)
+    return target_file_path
+
+
+@activity.defn
 async def merge_output_files(data: MergeOutputFilesInput) -> str | None:
     """
     Activity to merge multiple batch files into a single file.
@@ -288,7 +298,10 @@ async def export_dataset_to_upload(data: ExportDatasetInput) -> str:
     with open(metadata_path, 'w', encoding='utf-8') as metafile:
         json.dump(metadata_dict, metafile, indent=4)
 
-    exportable_filepaths = data.source_paths + [metadata_path]
+    exportable_filepaths = [metadata_path]
+    if data.source_path:
+        exportable_filepaths.append(data.source_path)
+
     exportable_dir_name = unique_filename(data.exportable_dir_name, upload_files)
 
     # Create a zip file containing all the source paths and the metadata file

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import zipfile
 from datetime import datetime, timezone
-from math import ceil
 
 from nomad.actions.manager import action_artifacts_dir, get_upload_files
 from nomad.app.v1.models.models import MetadataPagination, MetadataRequired
@@ -14,22 +13,17 @@ from temporalio import activity
 
 from nomad_ml_workflows.actions.export_entries.models import (
     CleanupArtifactsInput,
-    CollectCursorsInput,
-    CollectCursorsOutput,
     CreateArtifactSubdirectoryInput,
     ExportDatasetInput,
     ManifestEntry,
-    MergeOutputFilesInput,
     OutputFile,
     PrepapeManifestOutput,
     PrepareManifestInput,
     ReadArchivesWorkflowInput,
-    RenameGeneratedFileInput,
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
     generate_archives,
     generate_table_rows,
-    merge_files,
     write_dicts_to_json,
     write_table_rows_to_ndjson,
     write_table_rows_to_tabular_file,
@@ -59,80 +53,6 @@ async def create_artifact_subdirectory(data: CreateArtifactSubdirectoryInput) ->
     os.makedirs(subdir_path)
 
     return subdir_path
-
-
-@activity.defn
-async def collect_page_cursors(data: CollectCursorsInput) -> CollectCursorsOutput:
-    """
-    Activity to serially walk NOMAD search pagination and collect all
-    page_after_value cursors needed for parallel page fetching.
-
-    Only entry IDs are requested to minimise payload size.
-
-    Assumption: The cursors are valid for any subsequent search with the same query,
-    regardless of the required fields used in those searches.
-
-    Args:
-        data (CollectCursorsInput): Input data specifying the search and limits.
-
-    Returns:
-        CollectCursorsOutput: All page cursors and the total entry count.
-    """
-
-    # Use minimal required fields so the probe searches are as fast as possible.
-    required = MetadataRequired(include=['entry_id'])
-
-    # First page: cursor is None (start of results).
-    pagination = MetadataPagination(page_size=data.page_size)
-    response = nomad_search(
-        user_id=data.user_id,
-        owner=data.owner,
-        query=data.query,
-        required=required,
-        pagination=pagination,
-        aggregations={},
-    )
-
-    # determine the number of pages needed, incl. the first page
-    num_entries_available = response.pagination.total
-    num_entries_to_export = min(num_entries_available, data.max_entries_export_limit)
-    num_pages = (
-        ceil(num_entries_to_export / data.page_size) if num_entries_to_export > 0 else 0
-    )
-
-    if num_pages == 0:
-        return CollectCursorsOutput(
-            page_after_values=[],
-            num_entries_available=num_entries_available,
-            num_pages=num_pages,
-        )
-
-    # Collect the page_after_value cursor for each page.
-    # The first page starts with a None cursor.
-    page_after_values: list[str | None] = [None]
-    cursor = response.pagination.next_page_after_value
-    for _ in range(num_pages - 1):
-        if cursor is None:
-            break
-        page_after_values.append(cursor)
-        pagination = MetadataPagination(
-            page_size=data.page_size, page_after_value=cursor
-        )
-        response = nomad_search(
-            user_id=data.user_id,
-            owner=data.owner,
-            query=data.query,
-            required=required,
-            pagination=pagination,
-            aggregations={},
-        )
-        cursor = response.pagination.next_page_after_value
-
-    return CollectCursorsOutput(
-        page_after_values=page_after_values,
-        num_entries_available=num_entries_available,
-        num_pages=num_pages,
-    )
 
 
 @activity.defn
@@ -231,39 +151,6 @@ async def read_archives_and_write_output_tabular(
         file_size=os.path.getsize(output_file_path),
         num_entries_exported=num_entries_exported,
     )
-
-
-@activity.defn
-def rename_generated_file(data: RenameGeneratedFileInput) -> str | None:
-    target_file_path = os.path.join(
-        data.artifact_subdirectory, 'data.' + data.output_file_format
-    )
-    os.rename(data.generated_file_path, target_file_path)
-    return target_file_path
-
-
-@activity.defn
-async def merge_output_files(data: MergeOutputFilesInput) -> str | None:
-    """
-    Activity to merge multiple batch files into a single file.
-
-    Args:
-        data (MergeOutputFilesInput): Input data for merging files.
-
-    Returns:
-        str | None: Path of the merged output file, or None if no files were merged.
-    """
-
-    if not data.generated_file_paths:
-        raise ValueError('No generated file paths provided for merging.')
-
-    merged_file_path = os.path.join(
-        data.artifact_subdirectory, 'data.' + data.output_file_format
-    )
-
-    merge_files(data.generated_file_paths, data.output_file_format, merged_file_path)
-
-    return merged_file_path
 
 
 @activity.defn

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from math import ceil
 
 from nomad.actions.manager import action_artifacts_dir, get_upload_files
-from nomad.app.v1.models.models import MetadataPagination, MetadataRequired, User
+from nomad.app.v1.models.models import MetadataPagination, MetadataRequired
 from nomad.files import StagingUploadFiles
 from nomad.search import search as nomad_search
 from nomad.utils import get_logger
@@ -18,15 +18,22 @@ from nomad_ml_workflows.actions.export_entries.models import (
     CollectCursorsOutput,
     CreateArtifactSubdirectoryInput,
     ExportDatasetInput,
+    ManifestEntry,
     MergeOutputFilesInput,
+    OutputFile,
+    PrepapeManifestOutput,
+    PrepareManifestInput,
+    ReadArchivesAndWriteOutputJsonInput,
+    ReadArchivesAndWriteTableRowsInput,
     RenameGeneratedFileInput,
-    SearchPageInput,
-    SearchPageOutput,
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
+    generate_archives,
+    generate_table_rows,
     merge_files,
-    write_json_file,
+    write_dicts_to_json,
     write_parquet_file,
+    write_table_rows_to_json,
 )
 
 logger = get_logger(__name__)
@@ -130,75 +137,98 @@ async def collect_page_cursors(data: CollectCursorsInput) -> CollectCursorsOutpu
 
 
 @activity.defn
-async def read_archives(data: SearchPageInput) -> SearchPageOutput:
-    """
-    Activity to read archives of the searched entries. The required fields are read
-    from the archives and written to a file in the specified format (Parquet or JSON)
-    in the artifacts directory.
+def prepare_manifest(data: PrepareManifestInput) -> PrepapeManifestOutput:
 
-    Args:
-        data (ReadArchivesInput): Input data for the search activity.
-
-    Returns:
-        SearchPageOutput: Output data from the search and read archives activity.
-    """
-    from nomad.app.v1.routers.entries import _read_entry_from_archive, _Uploads
-    from nomad.archive.required import RequiredReader
-
-    start = datetime.now(timezone.utc).isoformat()
-
-    info = activity.info()
-
-    activity_logger = logger.bind(
-        activity_type=info.activity_type,
-        search_page_num=data.page_num,
-    )
-
-    # Find entries whose archives are to be read
+    starttime = datetime.now(timezone.utc).isoformat()
     response = nomad_search(
         user_id=data.user_id,
         owner=data.owner,
         query=data.query,
-        required=MetadataRequired(include=['entry_id', 'upload_id']),
+        required=MetadataRequired(include=['entry_id', 'upload_id']),  # type: ignore
         pagination=data.pagination,
     )
-    entries: list = [
-        {
-            'entry_id': entry['entry_id'],
-            'upload_id': entry['upload_id'],
-        }
+    endtime = datetime.now(timezone.utc).isoformat()
+
+    manifest: list = [
+        {'entry_id': entry['entry_id'], 'upload_id': entry['upload_id']}
         for entry in response.data
     ]
-    entries = entries[: data.max_entries_export_limit]  #  Apply max limit
+    manifest = manifest[: data.max_entries_export_limit]  #  Apply max limit
+    write_dicts_to_json(manifest, data.manifest_file_path)
 
-    # setup required reader
-    required_reader = RequiredReader(
-        data.required,
-        resolve_inplace=True,
-        user=User(user_id=data.user_id),
+    return PrepapeManifestOutput(
+        search_start_time=starttime,
+        search_end_time=endtime,
+        num_entries_available=len(manifest),
     )
-    entry_archives = []
 
-    # For each entry
-    with _Uploads() as uploads:
-        for entry in entries:
-            try:
-                entry_archive = _read_entry_from_archive(
-                    entry, uploads, required_reader
-                )
-                entry_archives.append(entry_archive)
-            except Exception as e:
-                activity_logger.error(
-                    'failed to read entry archive',
-                    entry_id=entry['entry_id'],
-                    exc_info=e,
-                )
 
-    end = datetime.now(timezone.utc).isoformat()
+@activity.defn
+def read_archives_and_write_output_json(
+    data: ReadArchivesAndWriteOutputJsonInput,
+) -> OutputFile:
+    """
+    Reads the archives and writes the output JSON file.
+    """
+    # load manifest
+    with open(data.manifest_path, encoding='utf-8') as f:
+        manifest = [ManifestEntry(**entry) for entry in json.load(f)]
 
+    info = activity.info()
+    activity_logger = logger.bind(activity_type=info.activity_type)
+
+    archives = generate_archives(manifest, data.required, data.user_id, activity_logger)
+    num_entries_exported = write_dicts_to_json(archives, data.output_file_path)
+
+    return OutputFile(
+        file_path=data.output_file_path,
+        file_size=os.path.getsize(data.output_file_path),
+        num_entries_exported=num_entries_exported,
+    )
+
+
+@activity.defn
+async def read_archives_and_write_table_rows(data: ReadArchivesAndWriteTableRowsInput):
+    """
+    Activity to read archives of the searched entries. The required fields are read
+    from the archives, converted to table rows, and written to a JSON file in the
+    artifact directory. At the same time, a list of required m_definitions is written to
+    another JSON file.
+
+    Args:
+        data (ReadArchivesAndWriteTableRowsInput): Input data for the search activity.
+
+    Returns:
+        SearchPageOutput: Output data from the search and read archives activity.
+    """
+    # load manifest
+    with open(data.manifest_path, encoding='utf-8') as f:
+        manifest = [ManifestEntry(**entry) for entry in json.load(f)]
+
+    info = activity.info()
+    activity_logger = logger.bind(activity_type=info.activity_type)
+
+    rows_with_definitions = generate_table_rows(
+        manifest, data.required, data.user_id, activity_logger
+    )
+
+    columns_quantity_def = write_table_rows_to_json(
+        rows_with_definitions, data.table_rows_file_path
+    )
+
+    write_dicts_to_json([columns_quantity_def], data.columns_quantity_def_file_path)
+
+
+@activity.defn
+def write_output_file_tabular(
+    data: ReadArchivesAndWriteTableRowsInput, entry_archives: list[dict]
+) -> OutputFile:
+    """
+    Writes the output file based on the batch file format.
+    """
     write_dataset_file = {
         'parquet': write_parquet_file,
-        'json': write_json_file,
+        # 'csv': write_csv_file,
     }.get(data.batch_file_format)
     if write_dataset_file is None:
         raise ValueError(f'Unsupported batch file format "{data.batch_file_format}". ')
@@ -216,10 +246,9 @@ async def read_archives(data: SearchPageInput) -> SearchPageOutput:
         f'exported {num_entries_exported}/{len(entry_archives)} entries'
     )
 
-    return SearchPageOutput(
-        search_start_time=start,
-        search_end_time=end,
-        num_entries_exported=num_entries_exported,
+    return OutputFile(
+        file_path=data.output_file_path,
+        file_size=os.path.getsize(data.output_file_path),
     )
 
 
@@ -299,8 +328,8 @@ async def export_dataset_to_upload(data: ExportDatasetInput) -> str:
         json.dump(metadata_dict, metafile, indent=4)
 
     exportable_filepaths = [metadata_path]
-    if data.source_path:
-        exportable_filepaths.append(data.source_path)
+    if data.source_paths:
+        exportable_filepaths.extend(data.source_paths)
 
     exportable_dir_name = unique_filename(data.exportable_dir_name, upload_files)
 

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -156,7 +156,7 @@ async def read_archives_and_write_output_tabular(
         table_rows_file_path,
         output_file_path,
         columns_quantity_def,
-        max_buffer_bytes=config.max_write_buffered_bytes,  # type: ignore
+        max_buffer_bytes=config.max_write_buffer_size_bytes,  # type: ignore
         logger=activity_logger,
     )
 

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -4,10 +4,11 @@ import shutil
 import zipfile
 from datetime import datetime, timezone
 
-from nomad.actions.manager import action_artifacts_dir, get_upload_files
-from nomad.app.v1.models.models import MetadataPagination, MetadataRequired
+from nomad.actions.manager import action_artifacts_dir
+from nomad.app.v1.models.models import MetadataRequired
 from nomad.files import StagingUploadFiles
 from nomad.search import search as nomad_search
+from nomad.uploads import get_upload_files
 from nomad.utils import get_logger
 from temporalio import activity
 
@@ -179,9 +180,9 @@ async def export_dataset_to_upload(data: ExportDatasetInput) -> str:
             count += 1
 
     upload_files = get_upload_files(data.upload_id, data.user_id)
-    if not upload_files:
+    if not upload_files or not isinstance(upload_files, StagingUploadFiles):
         raise ValueError(
-            f'Upload with ID {data.upload_id} for user {data.user_id} not found.'
+            f'Staging upload with ID {data.upload_id} for user {data.user_id} not found.'
         )
 
     # Create a metadata.json file in the artifact subdirectory

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -315,11 +315,11 @@ class ExportDatasetMetadata(BaseModel):
     )
     search_start_time: str = Field(
         '',
-        description='UTC Timestamp (ISO) when the first search batch started.',
+        description='UTC Timestamp (ISO) when the search for entries started.',
     )
     search_end_time: str = Field(
         '',
-        description='UTC Timestamp (ISO) when the last search batch completed.',
+        description='UTC Timestamp (ISO) when the search for entries ended.',
     )
     user_input: ExportEntriesUserInput | None = Field(
         None, description='Original user input for the export entries workflow.'

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -263,7 +263,12 @@ class PrepareManifestInput(BaseModel):
 
 class PrepapeManifestOutput(BaseModel):
     num_entries_available: int = Field(
-        ..., description='Number of entries available for export.'
+        ..., description='Total number of entries matching the search query.'
+    )
+    num_entries_selected: int = Field(
+        ...,
+        description='Number of matching entries selected for export after applying '
+        'the export limit.',
     )
     search_start_time: str = Field(
         ..., description='UTC Timestamp (ISO) when the search started.'
@@ -273,7 +278,7 @@ class PrepapeManifestOutput(BaseModel):
     )
     reached_max_entries_limit: bool = Field(
         ...,
-        description='Whether the maximum number of entries export limit was reached.',
+        description='Whether the number of matching entries exceeded the export limit.',
     )
 
 
@@ -304,14 +309,18 @@ class ExportDatasetMetadata(BaseModel):
     )
     num_entries_available: int = Field(
         0,
-        description='Number of entries available for the given search query. Limited by '
-        'the maximum number of entries allowed.',
+        description='Total number of entries matching the search query.',
+    )
+    num_entries_selected: int = Field(
+        0,
+        description='Number of matching entries selected for export after applying '
+        'the export limit.',
     )
     reached_max_entries_limit: bool = Field(
         False,
-        description='Indicates whether the export reached the maximum number of '
-        'entries allowed. If true, the exported dataset contains the first N entries '
-        'up to the maximum limit.',
+        description='Indicates whether the number of matching entries exceeded the '
+        'export limit. If true, the exported dataset contains only the first N entries '
+        'up to that limit.',
     )
     search_start_time: str = Field(
         '',

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -243,18 +243,6 @@ class NormalizedSearchSettings(BaseModel):
         )
 
 
-class SearchPageOutput(BaseModel):
-    num_entries_exported: int = Field(
-        ..., description='Number of entries exported to the output file.'
-    )
-    search_start_time: str = Field(
-        ..., description='UTC Timestamp (ISO) when the first search started.'
-    )
-    search_end_time: str = Field(
-        ..., description='UTC Timestamp (ISO) when the last search completed.'
-    )
-
-
 class ManifestEntry(BaseModel):
     entry_id: str = Field(..., description='Entry ID.')
     upload_id: str = Field(..., description='Upload ID.')
@@ -303,64 +291,6 @@ class OutputFile(BaseModel):
     file_path: str = Field(..., description='Path to the output file.')
     file_size: int = Field(..., description='Size of the output file in bytes.')
     num_entries_exported: int = Field(..., description='Number of entries exported.')
-
-
-class CollectCursorsInput(BaseModel):
-    user_id: str = Field(..., description='User ID performing the search.')
-    owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
-    query: Query = Field(..., description='Search query parameters.')
-    page_size: int = Field(..., description='Number of entries per page.')
-    max_entries_export_limit: int = Field(
-        ..., description='Maximum number of entries to be exported.'
-    )
-
-
-class CollectCursorsOutput(BaseModel):
-    page_after_values: list[str | None] = Field(
-        ...,
-        description='List of page_after_value cursors, one per page. '
-        'The first entry is None (start of first page) when at least one page is '
-        'available. If num_entries_available is 0, it is an empty list.',
-    )
-    num_entries_available: int = Field(
-        ...,
-        description='Total number of entries available for the given search query.',
-    )
-    num_pages: int = Field(
-        ...,
-        description='Total number of pages needed to export the entries, based on the '
-        'page size and max entries export limit.',
-    )
-
-
-class RenameGeneratedFileInput(BaseModel):
-    artifact_subdirectory: str = Field(
-        ...,
-        description='Subdirectory where the file will be renamed.',
-    )
-    output_file_format: OutputFileFormatLiteral = Field(
-        ...,
-        description='Format of the output file.',
-    )
-    generated_file_path: str = Field(
-        ...,
-        description='Path of generated file that will be renamed.',
-    )
-
-
-class MergeOutputFilesInput(BaseModel):
-    artifact_subdirectory: str = Field(
-        ...,
-        description='Subdirectory where the merged output file will be stored.',
-    )
-    output_file_format: OutputFileFormatLiteral = Field(
-        ...,
-        description='Format of the output file.',
-    )
-    generated_file_paths: list[str] = Field(
-        ...,
-        description='List of the generated file paths to be merged into a single file.',
-    )
 
 
 class ExportDatasetMetadata(BaseModel):

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -1,12 +1,17 @@
 import json
 from typing import Annotated, Any, Literal
 
-from nomad.app.v1.models.models import MetadataPagination, Query
+from nomad.app.v1.models.models import Query
+from nomad.config import config as nomad_config
 from pydantic import BaseModel, Field
 
 OwnerLiteral = Literal['public', 'visible', 'shared', 'user', 'staging']
 BatchFileFormatLiteral = Literal['parquet', 'json']
 OutputFileFormatLiteral = Literal['parquet', 'csv', 'json']
+
+config = nomad_config.get_plugin_entry_point(
+    'nomad_ml_workflows.actions:export_entries'
+)
 
 
 class Include(BaseModel):
@@ -91,11 +96,11 @@ class SearchSettings(BaseModel):
     owner: OwnerLiteral = Field(
         'visible', description='Owner of the entries to be searched.'
     )
-    page_size: int = Field(
-        1000,
+    num_entries: int = Field(
+        config.max_entries_export_limit,  # type: ignore
         gt=0,
-        description='Number of entries to be fetched and written per search page. '
-        'Use smaller page sizes when exporting large entries to reduce memory usage.',
+        le=config.max_entries_export_limit,  # type: ignore
+        description='Number of entries to be exported.',
     )
     query: str = Field(
         ...,
@@ -157,13 +162,13 @@ class NormalizedSearchSettings(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
     query: Query = Field(..., description='Search query parameters.')
+    num_entries_user_limit: int = Field(
+        ..., description='Number of entries requested by the user.'
+    )
     required: str | dict[str, Any] = Field(
         '*',
         description='Dictionary of required fields and directives compatible with '
         '`nomad.archive.required.RequiredReader` class.',
-    )
-    pagination: MetadataPagination = Field(
-        ..., description='Pagination settings for the search results.'
     )
 
     @staticmethod
@@ -232,14 +237,12 @@ class NormalizedSearchSettings(BaseModel):
             user_input.search_settings.required
         )
 
-        pagination = MetadataPagination(page_size=user_input.search_settings.page_size)  # type: ignore
-
         return cls(
             user_id=user_input.user_id,
             owner=user_input.search_settings.owner,
             query=query,
+            num_entries_user_limit=user_input.search_settings.num_entries,
             required=archive_required,
-            pagination=pagination,
         )
 
 
@@ -252,11 +255,8 @@ class PrepareManifestInput(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
     query: Query = Field(..., description='Search query parameters.')
-    pagination: MetadataPagination = Field(
-        ..., description='Pagination settings for the search results.'
-    )
-    max_entries_export_limit: int = Field(
-        ..., description='Maximum number of entries to be exported.'
+    num_entries_user_limit: int = Field(
+        ..., description='Number of entries requested by the user.'
     )
     manifest_file_path: str = Field(..., description='Path to the manifest file.')
 
@@ -270,6 +270,10 @@ class PrepapeManifestOutput(BaseModel):
     )
     search_end_time: str = Field(
         ..., description='UTC Timestamp (ISO) when the search ended.'
+    )
+    reached_max_entries_limit: bool = Field(
+        ...,
+        description='Whether the maximum number of entries export limit was reached.',
     )
 
 
@@ -296,12 +300,12 @@ class OutputFile(BaseModel):
 class ExportDatasetMetadata(BaseModel):
     num_entries_exported: int = Field(
         0,
-        description='Total number of entries exported in all the exported dataset '
-        'batches.',
+        description='Number of entries that were successfully exported in the data file. ',
     )
     num_entries_available: int = Field(
         0,
-        description='Total number of entries available for the given search query.',
+        description='Number of entries available for the given search query. Limited by '
+        'the maximum number of entries allowed.',
     )
     reached_max_entries_limit: bool = Field(
         False,

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -299,33 +299,6 @@ class ReadArchivesWorkflowInput(BaseModel):
     )
 
 
-class ReadArchivesAndWriteOutputJsonInput(BaseModel):
-    user_id: str = Field(..., description='User ID performing the search.')
-    manifest_path: str = Field(..., description='Path to the manifest file.')
-    required: str | dict[str, Any] = Field(
-        '*',
-        description='Dictionary of required fields and directives compatible with '
-        '`nomad.archive.required.RequiredReader` class.',
-    )
-    output_file_path: str = Field(..., description='Path to the output JSON file.')
-
-
-class ReadArchivesAndWriteTableRowsInput(BaseModel):
-    user_id: str = Field(..., description='User ID performing the search.')
-    manifest_path: str = Field(..., description='Path to the manifest file.')
-    required: str | dict[str, Any] = Field(
-        '*',
-        description='Dictionary of required fields and directives compatible with '
-        '`nomad.archive.required.RequiredReader` class.',
-    )
-    table_rows_file_path: str = Field(
-        ..., description='Path to the table rows output file.'
-    )
-    columns_quantity_def_file_path: str = Field(
-        ..., description='Path to the column quantity definitions output file.'
-    )
-
-
 class OutputFile(BaseModel):
     file_path: str = Field(..., description='Path to the output file.')
     file_size: int = Field(..., description='Size of the output file in bytes.')
@@ -333,11 +306,11 @@ class OutputFile(BaseModel):
 
 
 class TableRowsOutput(BaseModel):
-    table_rows_json_path: str = Field(
-        ..., description='Path to the JSON file containing table rows.'
+    table_rows_file_path: str = Field(
+        ..., description='Path to the table rows output file.'
     )
-    column_m_defs_json_path: str = Field(
-        ..., description='Path to the JSON file containing m_defs of the table columns.'
+    columns_quantity_def_file_path: str = Field(
+        ..., description='Path to the column quantity definitions output file.'
     )
 
 

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -97,7 +97,7 @@ class SearchSettings(BaseModel):
         'visible', description='Owner of the entries to be searched.'
     )
     max_entries: int = Field(
-        config.max_entries_export_limit,  # type: ignore
+        min(1000, config.max_entries_export_limit),  # type: ignore
         gt=0,
         le=config.max_entries_export_limit,  # type: ignore
         description='Maximum number of entries to be exported.',
@@ -113,8 +113,8 @@ class SearchSettings(BaseModel):
             'uiSchema': {'ui:widget': 'textarea', 'ui:options': {'rows': 5}}
         },
     )
-    required: list[Required] | None = Field(
-        None,
+    required: list[Required] = Field(
+        [],
         description='Required archive paths for filtering the search results. '
         'Paths can target quantities like "results.method.method_name" or '
         'sub-sections like "results".',
@@ -172,7 +172,7 @@ class NormalizedSearchSettings(BaseModel):
     )
 
     @staticmethod
-    def build_archive_required(required: list[Required] | None) -> str | dict[str, Any]:
+    def build_archive_required(required: list[Required]) -> str | dict[str, Any]:
         """Convert archive paths to a RequiredReader specification."""
         if not required:
             return '*'

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -261,7 +261,7 @@ class PrepareManifestInput(BaseModel):
     manifest_file_path: str = Field(..., description='Path to the manifest file.')
 
 
-class PrepapeManifestOutput(BaseModel):
+class PrepareManifestOutput(BaseModel):
     num_entries_available: int = Field(
         ..., description='Total number of entries matching the search query.'
     )

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -305,6 +305,21 @@ class CollectCursorsOutput(BaseModel):
     )
 
 
+class RenameGeneratedFileInput(BaseModel):
+    artifact_subdirectory: str = Field(
+        ...,
+        description='Subdirectory where the file will be renamed.',
+    )
+    output_file_format: OutputFileFormatLiteral = Field(
+        ...,
+        description='Format of the output file.',
+    )
+    generated_file_path: str = Field(
+        ...,
+        description='Path of generated file that will be renamed.',
+    )
+
+
 class MergeOutputFilesInput(BaseModel):
     artifact_subdirectory: str = Field(
         ...,
@@ -374,8 +389,8 @@ class ExportDatasetInput(BaseModel):
         description='Name of the directory containing the dataset that will be '
         'exported.',
     )
-    source_paths: list[str] = Field(
-        ..., description='List of paths to the source files of the dataset.'
+    source_path: str | None = Field(
+        None, description='Path to the source files of the dataset.'
     )
     metadata: ExportDatasetMetadata = Field(
         ..., description='Metadata associated with the exported dataset.'

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -360,8 +360,8 @@ class ExportDatasetInput(BaseModel):
         description='Name of the directory containing the dataset that will be '
         'exported.',
     )
-    source_paths: list[str] | None = Field(
-        None, description='Paths to the source files of the dataset.'
+    source_paths: list[str] = Field(
+        ..., description='Paths to the source files of the dataset.'
     )
     metadata: ExportDatasetMetadata = Field(
         ..., description='Metadata associated with the exported dataset.'

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -284,7 +284,9 @@ class PrepareManifestOutput(BaseModel):
 
 class ReadArchivesWorkflowInput(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
-    output_file_format: str = Field(..., description='Output file format.')
+    output_file_format: OutputFileFormatLiteral = Field(
+        ..., description='Output file format.'
+    )
     manifest_file_path: str = Field(..., description='Path to the manifest file.')
     artifact_subdirectory: str = Field(
         ..., description="Subdirectory where current workflow's artifacts are stored."

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -305,15 +305,6 @@ class OutputFile(BaseModel):
     num_entries_exported: int = Field(..., description='Number of entries exported.')
 
 
-class TableRowsOutput(BaseModel):
-    table_rows_file_path: str = Field(
-        ..., description='Path to the table rows output file.'
-    )
-    columns_quantity_def_file_path: str = Field(
-        ..., description='Path to the column quantity definitions output file.'
-    )
-
-
 class CollectCursorsInput(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -1,7 +1,7 @@
 import json
 from typing import Annotated, Any, Literal
 
-from nomad.app.v1.models.models import MetadataPagination, Query, owner_documentation
+from nomad.app.v1.models.models import MetadataPagination, Query
 from pydantic import BaseModel, Field
 
 OwnerLiteral = Literal['public', 'visible', 'shared', 'user', 'staging']

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -1,7 +1,7 @@
 import json
 from typing import Annotated, Any, Literal
 
-from nomad.app.v1.models.models import MetadataPagination, Query
+from nomad.app.v1.models.models import MetadataPagination, Query, owner_documentation
 from pydantic import BaseModel, Field
 
 OwnerLiteral = Literal['public', 'visible', 'shared', 'user', 'staging']
@@ -153,7 +153,7 @@ class CreateArtifactSubdirectoryInput(BaseModel):
     subdir_name: str = Field(..., description='Name of the subdirectory to be created.')
 
 
-class SearchPageInput(BaseModel):
+class NormalizedSearchSettings(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
     query: Query = Field(..., description='Search query parameters.')
@@ -165,14 +165,6 @@ class SearchPageInput(BaseModel):
     pagination: MetadataPagination = Field(
         ..., description='Pagination settings for the search results.'
     )
-    batch_file_format: BatchFileFormatLiteral = Field(
-        ..., description='Format of the output file.'
-    )
-    output_file_path: str = Field(..., description='Path to the generated output file.')
-    max_entries_export_limit: int = Field(
-        ..., description='Maximum number of entries to be exported.'
-    )
-    page_num: int = Field(..., description='Page number for the search results.')
 
     @staticmethod
     def build_archive_required(required: list[Required] | None) -> str | dict[str, Any]:
@@ -231,13 +223,7 @@ class SearchPageInput(BaseModel):
     def from_user_input(
         cls,
         user_input: ExportEntriesUserInput,
-        /,
-        page_num: int,
-        output_file_path: str,
-        max_entries_export_limit: int,
-    ) -> 'SearchPageInput':
-        """Convert from ExportEntriesUserInput to SearchPageInput"""
-
+    ) -> 'NormalizedSearchSettings':
         query = json.loads(
             _clean_field(user_input.search_settings.query).replace("'", '"')
         )
@@ -246,11 +232,7 @@ class SearchPageInput(BaseModel):
             user_input.search_settings.required
         )
 
-        pagination = MetadataPagination(page_size=user_input.search_settings.page_size)
-
-        batch_file_format = user_input.output_settings.output_file_format
-        if batch_file_format == 'csv':
-            batch_file_format = 'parquet'  # use parquet batches for csv
+        pagination = MetadataPagination(page_size=user_input.search_settings.page_size)  # type: ignore
 
         return cls(
             user_id=user_input.user_id,
@@ -258,10 +240,6 @@ class SearchPageInput(BaseModel):
             query=query,
             required=archive_required,
             pagination=pagination,
-            batch_file_format=batch_file_format,
-            page_num=page_num,
-            output_file_path=output_file_path,
-            max_entries_export_limit=max_entries_export_limit,
         )
 
 
@@ -274,6 +252,92 @@ class SearchPageOutput(BaseModel):
     )
     search_end_time: str = Field(
         ..., description='UTC Timestamp (ISO) when the last search completed.'
+    )
+
+
+class ManifestEntry(BaseModel):
+    entry_id: str = Field(..., description='Entry ID.')
+    upload_id: str = Field(..., description='Upload ID.')
+
+
+class PrepareManifestInput(BaseModel):
+    user_id: str = Field(..., description='User ID performing the search.')
+    owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
+    query: Query = Field(..., description='Search query parameters.')
+    pagination: MetadataPagination = Field(
+        ..., description='Pagination settings for the search results.'
+    )
+    max_entries_export_limit: int = Field(
+        ..., description='Maximum number of entries to be exported.'
+    )
+    manifest_file_path: str = Field(..., description='Path to the manifest file.')
+
+
+class PrepapeManifestOutput(BaseModel):
+    num_entries_available: int = Field(
+        ..., description='Number of entries available for export.'
+    )
+    search_start_time: str = Field(
+        ..., description='UTC Timestamp (ISO) when the search started.'
+    )
+    search_end_time: str = Field(
+        ..., description='UTC Timestamp (ISO) when the search ended.'
+    )
+
+
+class ReadArchivesWorkflowInput(BaseModel):
+    user_id: str = Field(..., description='User ID performing the search.')
+    output_file_format: str = Field(..., description='Output file format.')
+    manifest_file_path: str = Field(..., description='Path to the manifest file.')
+    artifact_subdirectory: str = Field(
+        ..., description="Subdirectory where current workflow's artifacts are stored."
+    )
+    required: str | dict[str, Any] = Field(
+        '*',
+        description='Dictionary of required fields and directives compatible with '
+        '`nomad.archive.required.RequiredReader` class.',
+    )
+
+
+class ReadArchivesAndWriteOutputJsonInput(BaseModel):
+    user_id: str = Field(..., description='User ID performing the search.')
+    manifest_path: str = Field(..., description='Path to the manifest file.')
+    required: str | dict[str, Any] = Field(
+        '*',
+        description='Dictionary of required fields and directives compatible with '
+        '`nomad.archive.required.RequiredReader` class.',
+    )
+    output_file_path: str = Field(..., description='Path to the output JSON file.')
+
+
+class ReadArchivesAndWriteTableRowsInput(BaseModel):
+    user_id: str = Field(..., description='User ID performing the search.')
+    manifest_path: str = Field(..., description='Path to the manifest file.')
+    required: str | dict[str, Any] = Field(
+        '*',
+        description='Dictionary of required fields and directives compatible with '
+        '`nomad.archive.required.RequiredReader` class.',
+    )
+    table_rows_file_path: str = Field(
+        ..., description='Path to the table rows output file.'
+    )
+    columns_quantity_def_file_path: str = Field(
+        ..., description='Path to the column quantity definitions output file.'
+    )
+
+
+class OutputFile(BaseModel):
+    file_path: str = Field(..., description='Path to the output file.')
+    file_size: int = Field(..., description='Size of the output file in bytes.')
+    num_entries_exported: int = Field(..., description='Number of entries exported.')
+
+
+class TableRowsOutput(BaseModel):
+    table_rows_json_path: str = Field(
+        ..., description='Path to the JSON file containing table rows.'
+    )
+    column_m_defs_json_path: str = Field(
+        ..., description='Path to the JSON file containing m_defs of the table columns.'
     )
 
 
@@ -389,8 +453,8 @@ class ExportDatasetInput(BaseModel):
         description='Name of the directory containing the dataset that will be '
         'exported.',
     )
-    source_path: str | None = Field(
-        None, description='Path to the source files of the dataset.'
+    source_paths: list[str] | None = Field(
+        None, description='Paths to the source files of the dataset.'
     )
     metadata: ExportDatasetMetadata = Field(
         ..., description='Metadata associated with the exported dataset.'

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -96,11 +96,11 @@ class SearchSettings(BaseModel):
     owner: OwnerLiteral = Field(
         'visible', description='Owner of the entries to be searched.'
     )
-    num_entries: int = Field(
+    max_entries: int = Field(
         config.max_entries_export_limit,  # type: ignore
         gt=0,
         le=config.max_entries_export_limit,  # type: ignore
-        description='Number of entries to be exported.',
+        description='Maximum number of entries to be exported.',
     )
     query: str = Field(
         ...,
@@ -163,7 +163,7 @@ class NormalizedSearchSettings(BaseModel):
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')
     query: Query = Field(..., description='Search query parameters.')
     num_entries_user_limit: int = Field(
-        ..., description='Number of entries requested by the user.'
+        ..., description='Maximum number of entries requested by the user.'
     )
     required: str | dict[str, Any] = Field(
         '*',
@@ -241,7 +241,7 @@ class NormalizedSearchSettings(BaseModel):
             user_id=user_input.user_id,
             owner=user_input.search_settings.owner,
             query=query,
-            num_entries_user_limit=user_input.search_settings.num_entries,
+            num_entries_user_limit=user_input.search_settings.max_entries,
             required=archive_required,
         )
 

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -530,6 +530,41 @@ def archives_to_arrow_table(archives: list[dict] | dict, logger=None) -> pa.Tabl
     return pa.Table.from_arrays(arrays, names=column_names)
 
 
+def _table_column_configs(
+    columns_quantity_def: dict[str, Quantity],
+) -> dict[str, _ArrowColumnConfig]:
+    """
+    Build ordered Arrow column configs based on the columns quantity definition.
+    Adds 'entry_id' and 'upload_id' columns to the configs.
+    """
+    configs = {
+        column: _quantity_to_arrow_column_config(quantity_def)
+        for column, quantity_def in columns_quantity_def.items()
+    }
+    configs['entry_id'] = _ArrowColumnConfig(pa.string())
+    configs['upload_id'] = _ArrowColumnConfig(pa.string())
+    return {column: configs[column] for column in _ordered_columns(configs)}
+
+
+def _table_rows_to_arrow_batch(
+    rows: list[dict],
+    column_configs: dict[str, _ArrowColumnConfig],
+    schema: pa.Schema,
+    logger=None,
+) -> pa.RecordBatch:
+    """Convert a batch of flattened rows using a fixed Arrow schema."""
+    arrays = [
+        _normalize_arrow_column(
+            [row.get(column_name) for row in rows],
+            config,
+            column_name,
+            logger=logger,
+        )
+        for column_name, config in column_configs.items()
+    ]
+    return pa.RecordBatch.from_arrays(arrays, schema=schema)
+
+
 def _is_nested_type(dtype: pa.DataType) -> bool:
     """Check if a PyArrow type is nested."""
     return pa.types.is_nested(dtype)
@@ -546,7 +581,9 @@ def _get_csv_compatible_schema(schema: pa.Schema) -> pa.Schema:
     return pa.schema(new_fields)
 
 
-def _stringify_nested_columns(batch: pa.RecordBatch) -> pa.RecordBatch:
+def _stringify_nested_columns(
+    batch: pa.RecordBatch, csv_schema: pa.Schema
+) -> pa.RecordBatch:
     """Convert nested columns (list, struct) in a batch to JSON strings."""
     new_columns = []
     for i, column in enumerate(batch.columns):
@@ -554,8 +591,10 @@ def _stringify_nested_columns(batch: pa.RecordBatch) -> pa.RecordBatch:
             # Convert each element to JSON string
             stringified = pa.array(
                 [
-                    json.dumps(val.as_py()) if val.as_py() is not None else None
-                    for val in column
+                    json.dumps(value, separators=(',', ':'))
+                    if value is not None
+                    else None
+                    for value in column.to_pylist()
                 ],
                 type=pa.string(),
             )
@@ -563,9 +602,7 @@ def _stringify_nested_columns(batch: pa.RecordBatch) -> pa.RecordBatch:
         else:
             new_columns.append(column)
 
-    return pa.RecordBatch.from_arrays(
-        new_columns, schema=_get_csv_compatible_schema(batch.schema)
-    )
+    return pa.RecordBatch.from_arrays(new_columns, schema=csv_schema)
 
 
 def write_parquet_file(path: str, data: list[dict], logger=None):
@@ -647,7 +684,7 @@ def merge_files(
         # Write the dataset to a single CSV file in batches
         with pcsv.CSVWriter(output_file_path, csv_schema) as writer:
             for batch in dataset.to_batches():
-                csv_batch = _stringify_nested_columns(batch)
+                csv_batch = _stringify_nested_columns(batch, csv_schema=csv_schema)
                 writer.write_batch(csv_batch)
 
     elif output_file_format == 'json':
@@ -780,3 +817,129 @@ def write_table_rows_to_json(
         file.write('\n]')
 
     return columns_quantity_def
+
+
+def _tabular_output_file_format(output_file_path: str) -> str:
+    output_file_format = output_file_path.rpartition('.')[2]
+    if output_file_format not in {'parquet', 'csv'}:
+        raise ValueError('Unsupported output file format. Please use parquet or csv.')
+    return output_file_format
+
+
+def _create_tabular_writer(
+    output_file_path: str,
+    output_file_format: str,
+    schema: pa.Schema,
+):
+    if output_file_format == 'csv':
+        return pcsv.CSVWriter(output_file_path, schema)
+    return pq.ParquetWriter(
+        output_file_path,
+        schema,
+        compression='zstd',
+        compression_level=3,
+        use_dictionary=True,
+    )
+
+
+def _write_tabular_table(writer, table: pa.Table, output_file_format: str) -> None:
+    if output_file_format == 'parquet':
+        writer.write_table(table, row_group_size=table.num_rows)
+    else:
+        writer.write_table(table)
+
+
+def write_table_rows_to_tabular_file(
+    table_rows_file_path: str,
+    output_file_path: str,
+    columns_quantity_def: dict[str, Quantity],
+    max_buffer_bytes: int = 2 * 1024 * 1024,
+    logger=None,
+) -> int:
+    """
+    Stream flattened rows from JSON into byte-bounded Parquet or CSV batches.
+
+    The complete set of quantity definitions is collected before this function is
+    called, allowing each row to be normalized once into a RecordBatch with the same
+    schema. Record batches are buffered until their total uncompressed Arrow size
+    reaches ``max_buffer_bytes``.
+
+    A single row is always accepted. If it is larger than ``max_buffer_bytes``, it is
+    logged and written immediately.
+    """
+    output_file_format = _tabular_output_file_format(output_file_path)
+    if max_buffer_bytes < 1:
+        raise ValueError('max_buffer_bytes must be at least 1.')
+
+    column_configs = _table_column_configs(columns_quantity_def)
+    arrow_schema = pa.schema(
+        [
+            pa.field(column_name, config.arrow_type)
+            for column_name, config in column_configs.items()
+        ]
+    )
+    output_schema = (
+        _get_csv_compatible_schema(arrow_schema)
+        if output_file_format == 'csv'
+        else arrow_schema
+    )
+
+    buffered_batches: list[pa.RecordBatch] = []
+    buffered_bytes = 0
+    count = 0
+
+    with (
+        open(table_rows_file_path, encoding='utf-8') as input_file,
+        _create_tabular_writer(
+            output_file_path, output_file_format, output_schema
+        ) as writer,
+    ):
+
+        def flush_batch() -> None:
+            nonlocal buffered_bytes, count
+            if not buffered_batches:
+                return
+
+            table = pa.Table.from_batches(buffered_batches, schema=output_schema)
+            _write_tabular_table(writer, table, output_file_format)
+            count += table.num_rows
+            buffered_batches.clear()
+            buffered_bytes = 0
+
+        for row in json_stream.load(input_file):
+            standard_row = json_stream.to_standard_types(row)
+            if not isinstance(standard_row, dict):
+                raise ValueError('Each table row must be a JSON object.')
+            row_batch = _table_rows_to_arrow_batch(
+                [standard_row],
+                column_configs,
+                arrow_schema,
+                logger=logger,
+            )
+            if output_file_format == 'csv':
+                row_batch = _stringify_nested_columns(row_batch, output_schema)
+            row_size_bytes = row_batch.nbytes
+
+            if buffered_batches and buffered_bytes + row_size_bytes > max_buffer_bytes:
+                flush_batch()
+
+            buffered_batches.append(row_batch)
+            buffered_bytes += row_size_bytes
+
+            if row_size_bytes > max_buffer_bytes:
+                if logger:
+                    logger.warning(
+                        'Tabular row exceeds the uncompressed buffer size and '
+                        'will be written immediately.',
+                        entry_id=standard_row.get('entry_id'),
+                        output_file_format=output_file_format,
+                        row_size_bytes=row_size_bytes,
+                        max_buffer_bytes=max_buffer_bytes,
+                    )
+                flush_batch()
+            elif buffered_bytes >= max_buffer_bytes:
+                flush_batch()
+
+        flush_batch()
+
+    return count

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -456,11 +456,14 @@ def _archives_to_rows(  # noqa: PLR0912
     return rows, columns_quantity_def
 
 
-def _ordered_columns(columns) -> list[str]:
+def _ordered_columns(columns: Iterable[str]) -> list[str]:
     """Put entry_id and upload_id first and sort all remaining columns alphabetically."""
-    return sorted(
-        columns, key=lambda column: (column != ['entry_id', 'upload_id'], column)
-    )
+    column_set = set(columns)
+    identifier_columns = [
+        column for column in ('entry_id', 'upload_id') if column in column_set
+    ]
+    remaining_columns = sorted(column_set.difference(identifier_columns))
+    return [*identifier_columns, *remaining_columns]
 
 
 def archives_to_dataframe(archives: list[dict] | dict, logger=None) -> pd.DataFrame:

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -321,6 +321,47 @@ def _flatten_section(
             )
 
 
+def archive_to_row(archive: dict) -> tuple[dict, dict[str, Quantity]]:
+    """
+    Flatten archive dict into a row dict. Also returns column definition.
+
+    `archive` argument should have the following structure, where `archive` corresponds
+    to serialization of EntryArchive::
+        {
+            "entry_id": str,
+            "archive": {
+                "results": dict,
+                "metadata": dict,
+                "data": dict,
+                "processing_log": list[Any],
+                ...
+            },
+        }
+    """
+    if not isinstance(archive, dict):
+        raise ValueError('archive must be a dictionary (JSON object).')
+    if 'archive' not in archive or 'entry_id' not in archive:
+        raise ValueError('archive and entry_id keys are required.')
+    if not isinstance(archive['archive'], dict):
+        raise ValueError('archive[archive] must be a dictionary (JSON object).')
+
+    columns_quantity_def: dict[str, Quantity] = {}
+    context = _FlattenEntryContext(
+        row={'entry_id': archive['entry_id']},  # Always include entry_id as a column
+        columns_quantity_def=columns_quantity_def,
+        unhandled_keys=[],
+    )
+    _flatten_section(
+        section_data=archive['archive'],
+        section_def=EntryArchive.m_def,
+        prefix='',
+        context=context,
+    )
+    columns_quantity_def.update(context.columns_quantity_def)
+
+    return context.row, columns_quantity_def
+
+
 def _archives_to_rows(  # noqa: PLR0912
     archives: list[dict] | dict, logger=None
 ) -> tuple[list[dict], dict[str, Quantity]]:

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -796,7 +796,7 @@ def write_table_rows_to_ndjson(
     rows_with_definitions: Iterable[tuple[dict, dict[str, Quantity]]],
     output_file_path: str,
 ) -> dict[str, Quantity]:
-    if not output_file_path.endswith('.ndjson')
+    if not output_file_path.endswith('.ndjson'):
         raise ValueError('ouput_file_path should have .ndjson extension.')
     columns_quantity_def: dict[str, Quantity] = {}
 

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -454,6 +454,8 @@ def generate_archives(
                     entry['archive'] = required_reader.read(
                         upload_archive, entry_id, upload_id
                     )
+                    if entry['archive'] is None:
+                        continue
                     yield entry
             except Exception as e:
                 if logger:

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -33,8 +33,8 @@ class _ArrowColumnConfig:
 
 
 @dataclass
-class _FlattenEntryContext:
-    row: dict[str, str | int | float | bool | dict | list | None]
+class FlatEntryArchive:
+    data_dict: dict[str, str | int | float | bool | dict | list | None]
     columns_quantity_def: dict[str, Quantity]
     unhandled_keys: list[str]
 
@@ -88,7 +88,7 @@ def _quantity_to_arrow_column_config(quantity_def: Quantity) -> _ArrowColumnConf
         return _ArrowColumnConfig(pa.string(), stringify_json=True)
 
     try:
-        standard_type = quantity_type.standard_type()
+        standard_type = quantity_type.standard_type()  # type: ignore
     except (AttributeError, NotImplementedError, TypeError, ValueError):
         return _ArrowColumnConfig(pa.string(), stringify_json=True)
 
@@ -230,7 +230,7 @@ def _flatten_section(
     section_data: dict,
     section_def: Section,
     prefix: str,
-    context: _FlattenEntryContext,
+    output: FlatEntryArchive,
 ):
     """
     Flatten one serialized NOMAD section using its metainfo definition.
@@ -248,15 +248,15 @@ def _flatten_section(
                 f'archive.data exists but schema definition "{m_def}" not found. Skipping entry.'
             )
 
-    for quantity_name, quantity_def in section_def.all_quantities.items():
+    for quantity_name, quantity_def in section_def.all_quantities.items():  # type: ignore
         if quantity_name not in section_data:
             continue
         handled_keys.add(quantity_name)
         col = f'{_join_path(prefix, quantity_name)}#{section_def.qualified_name()}'
-        context.columns_quantity_def.setdefault(col, quantity_def)
-        _store_leaf_value(context.row, col, section_data[quantity_name])
+        output.columns_quantity_def.setdefault(col, quantity_def)
+        _store_leaf_value(output.data_dict, col, section_data[quantity_name])
 
-    for sub_section_name, sub_section_def in section_def.all_sub_sections.items():
+    for sub_section_name, sub_section_def in section_def.all_sub_sections.items():  # type: ignore
         if sub_section_name not in section_data:
             continue
 
@@ -279,7 +279,7 @@ def _flatten_section(
                     item,
                     item_section_def or child_section_def,
                     item_prefix,
-                    context,
+                    output,
                 )
         else:
             # If m_def is available in the dict, get a section_def based on it.
@@ -290,62 +290,50 @@ def _flatten_section(
                 sub_section_value,
                 item_section_def or child_section_def,
                 sub_section_prefix,
-                context,
+                output,
             )
 
     # Add the unhandled keys to a list. These point to the obsolete data in the
     # archives that do not correspond to a subsection/quantity in the current schema
     for key, _ in section_data.items():
         if key not in [*handled_keys, *IGNORED_KEYS]:
-            context.unhandled_keys.append(
+            output.unhandled_keys.append(
                 f'{prefix}.{key}#{section_def.qualified_name()}'
             )
 
 
-def archive_to_row(archive: dict) -> tuple[dict, dict[str, Quantity]]:
+def _flatten_entry_archive(
+    entry_archive: dict,
+    entry_id: str = '',
+    upload_id: str = '',
+) -> FlatEntryArchive:
     """
-    Flatten archive dict into a row dict. Also returns column definition.
+    Convert a nested entry archive dict into a flat dict.
 
-    `archive` argument should have the following structure, where `archive` corresponds
-    to serialization of EntryArchive::
-        {
-            "entry_id": str,
-            "archive": {
-                "results": dict,
-                "metadata": dict,
-                "data": dict,
-                "processing_log": list[Any],
-                ...
-            },
+    `archive` should corresponds to serialization of EntryArchive::
+        "archive": {
+            "results": dict,
+            "metadata": dict,
+            "data": dict,
+            "processing_log": list[Any],
+            ...
         }
     """
-    if not isinstance(archive, dict):
-        raise ValueError('archive must be a dictionary (JSON object).')
-    if 'archive' not in archive or 'entry_id' not in archive:
-        raise ValueError('archive and entry_id keys are required.')
-    if not isinstance(archive['archive'], dict):
-        raise ValueError('archive[archive] must be a dictionary (JSON object).')
-
-    columns_quantity_def: dict[str, Quantity] = {}
-    context = _FlattenEntryContext(
-        row={
-            'entry_id': archive['entry_id'],
-            'upload_id': archive['upload_id'],
-        },  # Always include entry_id and upload_id as columns
-        columns_quantity_def=columns_quantity_def,
+    output = FlatEntryArchive(
+        data_dict={
+            'entry_id': entry_id,
+            'upload_id': upload_id,
+        },
+        columns_quantity_def={},
         unhandled_keys=[],
     )
     _flatten_section(
-        section_data=archive['archive'],
+        section_data=entry_archive,
         section_def=EntryArchive.m_def,
         prefix='',
-        context=context,
+        output=output,
     )
-    columns_quantity_def.update(context.columns_quantity_def)
-
-    return context.row, columns_quantity_def
-
-
+    return output
 
 
 def _ordered_columns(columns: Iterable[str]) -> list[str]:
@@ -479,19 +467,35 @@ def generate_archives(
 
 def generate_table_rows(
     manifest: list[ManifestEntry], required: dict | str, user_id: str, logger=None
-) -> Iterable[tuple[dict, dict[str, Quantity]]]:
+) -> Iterable[FlatEntryArchive]:
     """
     Generates table rows from the manifest and required fields.
     """
     archives = generate_archives(manifest, required, user_id, logger)
+
+    all_unhandled_keys: set[str] = set()
     for archive in archives:
+        entry_id = archive['entry_id']
+        upload_id = archive['upload_id']
         try:
-            yield archive_to_row(archive)
+            table_row = _flatten_entry_archive(
+                archive['archive'],
+                entry_id,
+                upload_id,
+            )
+            all_unhandled_keys.update(table_row.unhandled_keys)
+            yield table_row
         except Exception as e:
             logger.error(
-                'failed to generate table rows for archive',
+                'failed to flatten archive '
+                f'(entry_id={entry_id} upload_id={upload_id})',
                 exc_info=e,
             )
+    if all_unhandled_keys and logger:
+        logger.warning(
+            f'Unhandled keys ({len(all_unhandled_keys)}) while flattening '
+            f'archives: {all_unhandled_keys}'
+        )
 
 
 def write_dicts_to_json(items: Iterable[dict], output_file_path: str) -> int:
@@ -514,21 +518,20 @@ def write_dicts_to_json(items: Iterable[dict], output_file_path: str) -> int:
 
 
 def write_table_rows_to_ndjson(
-    rows_with_definitions: Iterable[tuple[dict, dict[str, Quantity]]],
-    output_file_path: str,
+    table_rows: Iterable[FlatEntryArchive], output_file_path: str
 ) -> dict[str, Quantity]:
     if not output_file_path.endswith('.ndjson'):
         raise ValueError('ouput_file_path should have .ndjson extension.')
     columns_quantity_def: dict[str, Quantity] = {}
 
     with open(output_file_path, 'w', encoding='utf-8') as file:
-        for row, row_column_defs in rows_with_definitions:
+        for table_row in table_rows:
             # accumulate only the schema information
-            for column, quantity_def in row_column_defs.items():
+            for column, quantity_def in table_row.columns_quantity_def.items():
                 columns_quantity_def.setdefault(column, quantity_def)
 
             # write the current row immediately
-            json.dump(row, file, separators=(',', ':'))
+            json.dump(table_row.data_dict, file, separators=(',', ':'))
             file.write('\n')
 
     return columns_quantity_def

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -566,6 +566,7 @@ def _write_tabular_table(writer, table: pa.Table, output_file_format: str) -> No
     if output_file_format == 'parquet':
         writer.write_table(table, row_group_size=table.num_rows)
     else:
+        # pcsv.CSVWriter.write_table does not support row_group_size
         writer.write_table(table)
 
 
@@ -573,7 +574,7 @@ def write_table_rows_to_tabular_file(
     table_rows_file_path: str,
     output_file_path: str,
     columns_quantity_def: dict[str, Quantity],
-    max_buffer_bytes: int = 2 * 1024 * 1024,
+    max_buffer_bytes: int = 4 * 1024 * 1024,
     logger=None,
 ) -> int:
     """
@@ -616,7 +617,7 @@ def write_table_rows_to_tabular_file(
     ):
 
         def flush_batch() -> None:
-            nonlocal buffered_bytes, count
+            nonlocal buffered_bytes, count  # update from flush
             if not buffered_batches:
                 return
 

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -748,3 +748,30 @@ def write_dicts_to_json(items: Iterable[dict], output_file_path: str) -> int:
         f.write('\n]')
 
     return count
+
+
+def write_table_rows_to_json(
+    rows_with_definitions: Iterable[tuple[dict, dict[str, Quantity]]],
+    output_file_path: str,
+) -> dict[str, Quantity]:
+    columns_quantity_def: dict[str, Quantity] = {}
+    first_row = True
+
+    with open(output_file_path, 'w', encoding='utf-8') as file:
+        file.write('[\n')
+
+        for row, row_column_defs in rows_with_definitions:
+            # Accumulate only the schema information.
+            for column, quantity_def in row_column_defs.items():
+                columns_quantity_def.setdefault(column, quantity_def)
+
+            # Write the current row immediately.
+            if not first_row:
+                file.write(',\n')
+
+            json.dump(row, file, indent=2)
+            first_row = False
+
+        file.write('\n]')
+
+    return columns_quantity_def

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -1,13 +1,20 @@
 import importlib
 import json
+from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import lru_cache
 
 import json_stream
 import pandas as pd
+from nomad.app.v1.models.models import User
+from nomad.archive.required import RequiredReader
 from nomad.datamodel.datamodel import EntryArchive, EntryData
+from nomad.files import UploadFiles
 from nomad.metainfo import data_type as nomad_data_type
 from nomad.metainfo.metainfo import Quantity, Reference, Section
+
+from nomad_ml_workflows.actions.export_entries.models import ManifestEntry
 
 try:
     import pyarrow as pa
@@ -578,8 +585,8 @@ def write_parquet_file(path: str, data: list[dict], logger=None):
     return table.num_rows
 
 
-def write_json_file(path: str, data: list[dict], logger=None):
-    """Writes a list of NOMAD entry dicts to a JSON file.
+def write_json_file(path: str, data, logger=None):
+    """Writes a JSON file with the given data.
 
     Args:
         path (str): The path where the file will be saved.
@@ -661,3 +668,83 @@ def merge_files(
 
     else:
         raise ValueError('Unsupported file format. Please use parquet, csv, or json.')
+
+
+def generate_archives(
+    manifest: list[ManifestEntry], required: dict | str, user_id: str, logger=None
+) -> Iterable[dict]:
+    """Generates entry archive dicts from the manifest and required fields."""
+
+    # set up required reader
+    required_reader = RequiredReader(
+        required=required,
+        resolve_inplace=True,
+        user=User(user_id=user_id),
+    )
+
+    # arrange entries by upload_id
+    manifest_dict = defaultdict(list)
+    for entry in manifest:
+        manifest_dict[entry.upload_id].append(entry.entry_id)
+
+    for upload_id, entry_ids in manifest_dict.items():
+        if logger:
+            logger.info(f'processing upload_id: {upload_id}')
+
+        upload_files = UploadFiles.get(upload_id)
+        if upload_files is None:
+            if logger:
+                logger.info(f'no upload files found for upload_id: {upload_id}')
+            continue
+
+        for entry_id in entry_ids:
+            entry = {'entry_id': entry_id, 'upload_id': upload_id}
+            try:
+                with upload_files.read_archive(entry_id) as archive:
+                    entry['archive'] = required_reader.read(
+                        archive, entry_id, upload_id
+                    )
+                    yield entry
+            except Exception as e:
+                logger.error(
+                    'failed to read entry archive',
+                    entry_id=entry_id,
+                    upload_id=upload_id,
+                    exc_info=e,
+                )
+
+
+def generate_table_rows(
+    manifest: list[ManifestEntry], required: dict | str, user_id: str, logger=None
+) -> Iterable[tuple[dict, dict[str, Quantity]]]:
+    """
+    Generates table rows from the manifest and required fields.
+    """
+    archives = generate_archives(manifest, required, user_id, logger)
+    for archive in archives:
+        try:
+            yield archive_to_row(archive)
+        except Exception as e:
+            logger.error(
+                'failed to generate table rows for archive',
+                exc_info=e,
+            )
+
+
+def write_dicts_to_json(items: Iterable[dict], output_file_path: str) -> int:
+    first_item = True
+    count = 0
+
+    with open(output_file_path, 'w', encoding='utf-8') as f:
+        f.write('[\n')
+
+        for item in items:
+            if not first_item:
+                f.write(',\n')
+            json.dump(item, f, indent=2)
+            count += 1
+            first_item = False
+
+        f.write('\n]')
+
+    return count

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -664,3 +664,9 @@ def write_table_rows_to_tabular_file(
         flush_batch()
 
     return count
+
+
+def worker_process_initializer() -> None:
+    from nomad.infrastructure import setup_mongo
+
+    setup_mongo()

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -5,8 +5,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import lru_cache
 
-import json_stream
-import pandas as pd
 from nomad.app.v1.models.models import User
 from nomad.archive.required import RequiredReader
 from nomad.datamodel.datamodel import EntryArchive, EntryData
@@ -19,7 +17,6 @@ from nomad_ml_workflows.actions.export_entries.models import ManifestEntry
 try:
     import pyarrow as pa
     import pyarrow.csv as pcsv
-    import pyarrow.dataset as ds
     import pyarrow.parquet as pq
 except ImportError as e:
     raise ImportError(
@@ -224,29 +221,6 @@ def _normalize_arrow_column(
     return pa.array(converted_values, type=config.arrow_type, safe=True)
 
 
-def _infer_arrow_column(values: list, column_name: str) -> pa.Array:
-    """Infer non-schema column types, falling back to deterministic JSON text."""
-    try:
-        array = pa.array(values)
-        return array
-    except (
-        pa.ArrowInvalid,
-        pa.ArrowNotImplementedError,
-        pa.ArrowTypeError,
-        OverflowError,
-        TypeError,
-        ValueError,
-    ):
-        try:
-            return pa.array(
-                [_json_stringify(value) for value in values], type=pa.string()
-            )
-        except (TypeError, ValueError) as error:
-            raise ValueError(
-                f'Cannot infer or JSON-encode column {column_name!r}.'
-            ) from error
-
-
 def _store_leaf_value(row: dict, col: str, value):
     """Store a value as one opaque DataFrame cell."""
     row[col] = value
@@ -372,88 +346,6 @@ def archive_to_row(archive: dict) -> tuple[dict, dict[str, Quantity]]:
     return context.row, columns_quantity_def
 
 
-def _archives_to_rows(  # noqa: PLR0912
-    archives: list[dict] | dict, logger=None
-) -> tuple[list[dict], dict[str, Quantity]]:
-    """
-    Flatten list of archive dicts into list of row dicts. Also returns column definition
-    and a count of unhandled archive dict keys.
-
-    Each element in the `archives` list should have the following structure, where
-    `archive` key corresponds to serialization of EntryArchive::
-        {
-            "entry_id": str,
-            "archive": {
-                "results": dict,
-                "metadata": dict,
-                "data": dict,
-                "processing_log": list[Any],
-                ...
-            },
-        }
-    """
-    if isinstance(archives, dict):
-        archives = [archives]
-    elif not isinstance(archives, list):
-        raise ValueError(
-            'Input must be a dictionary (JSON object) or a list of dictionaries '
-            '(JSON objects)'
-        )
-
-    rows = []
-    columns_quantity_def: dict[str, Quantity] = {}
-    failed_to_flatten = []
-    unhandled_key_entry_ids: dict[str, set[str]] = {}
-    for item in archives:
-        if item is None:
-            if logger:
-                logger.warning('Encountered a None item.')
-            continue
-        if not isinstance(item, dict):
-            raise ValueError('Input must be a dictionary (JSON object).')
-        if 'archive' not in item or 'entry_id' not in item:
-            raise ValueError('archive and entry_id keys are required.')
-        if not isinstance(item['archive'], dict):
-            raise ValueError('archive value must be a dictionary (JSON object).')
-
-        context = _FlattenEntryContext(
-            row={'entry_id': item['entry_id']},  # Always include entry_id as a column
-            columns_quantity_def=columns_quantity_def,
-            unhandled_keys=[],
-        )
-        try:
-            _flatten_section(
-                section_data=item['archive'],
-                section_def=EntryArchive.m_def,
-                prefix='',
-                context=context,
-            )
-            rows.append(context.row)
-            columns_quantity_def.update(context.columns_quantity_def)
-            for key in context.unhandled_keys:
-                unhandled_key_entry_ids.setdefault(key, set()).add(item['entry_id'])
-        except Exception as e:
-            if logger:
-                logger.warning(
-                    f'failed to flatten archive (entry_id={item["entry_id"]})',
-                    exc_info=e,
-                )
-            failed_to_flatten.append(item['entry_id'])
-
-    if logger:
-        # cummulative logging
-        for key, entry_ids_set in unhandled_key_entry_ids.items():
-            entry_ids = list(entry_ids_set)
-            logger.warning(
-                f'unhandled key {key} (num_entries={len(entry_ids)})',
-                entry_ids=entry_ids,
-            )
-        if failed_to_flatten:
-            logger.warning(
-                f'failed to flatten archives (num_entries={len(failed_to_flatten)})',
-            )
-
-    return rows, columns_quantity_def
 
 
 def _ordered_columns(columns: Iterable[str]) -> list[str]:
@@ -464,73 +356,6 @@ def _ordered_columns(columns: Iterable[str]) -> list[str]:
     ]
     remaining_columns = sorted(column_set.difference(identifier_columns))
     return [*identifier_columns, *remaining_columns]
-
-
-def archives_to_dataframe(archives: list[dict] | dict, logger=None) -> pd.DataFrame:
-    """
-    Convert serialized NOMAD entries into a flattened pandas DataFrame.
-
-    Archive traversal follows NOMAD metainfo subsections, while quantities remain
-    opaque cell values. Concrete ``m_def`` values are used to resolve schemas, and
-    pandas infers the resulting column dtypes from the flattened rows.
-    The ``entry_id`` column is returned first, followed by all other columns in
-    alphabetical order.
-
-    Args:
-        archives: A serialized entry dictionary or list of entry dictionaries. Each
-            entry may contain an ``archive`` dictionary and optional top-level data.
-
-    Returns:
-        A flattened DataFrame.
-    """
-    rows, _ = _archives_to_rows(archives, logger=logger)
-
-    df = pd.DataFrame(rows)
-    sorted_df = df.reindex(_ordered_columns(df.columns), axis=1)
-
-    return sorted_df
-
-
-def archives_to_arrow_table(archives: list[dict] | dict, logger=None) -> pa.Table:
-    """
-    Convert serialized NOMAD entries into a schema-typed Arrow table.
-
-    Entries are flattened using the same metainfo-aware traversal as
-    :func:`archives_to_dataframe`. Schema-backed columns receive explicit Arrow types
-    derived from their quantity definitions, including nested list dimensions. Values
-    are safely cast when necessary; JSON, ``Any``, references, complex numbers, and
-    unsupported custom datatypes are stored as deterministic JSON strings. Columns
-    without a NOMAD quantity definition use Arrow inference with the same JSON fallback.
-    The ``entry_id`` column is returned first, followed by all other columns in
-    alphabetical order.
-
-    Args:
-        archives: A serialized entry dictionary or list of entry dictionaries. Each
-            entry may contain an ``archive`` dictionary and optional top-level data.
-
-    Returns:
-        A schema-typed Arrow table.
-    """
-    rows, columns_quantity_def = _archives_to_rows(archives, logger)
-    column_names = _ordered_columns({column for row in rows for column in row})
-
-    arrays = []
-    for column_name in column_names:
-        values = [row.get(column_name) for row in rows]
-        quantity_def = columns_quantity_def.get(column_name)
-        if quantity_def is None:
-            array = _infer_arrow_column(values, column_name)
-        else:
-            config = _quantity_to_arrow_column_config(quantity_def)
-            array = _normalize_arrow_column(
-                values,
-                config,
-                column_name,
-                logger=logger,
-            )
-        arrays.append(array)
-
-    return pa.Table.from_arrays(arrays, names=column_names)
 
 
 def _table_column_configs(
@@ -605,113 +430,6 @@ def _stringify_nested_columns(
             new_columns.append(column)
 
     return pa.RecordBatch.from_arrays(new_columns, schema=csv_schema)
-
-
-def write_parquet_file(path: str, data: list[dict], logger=None):
-    """Writes a list of NOMAD entry dicts to a parquet file.
-
-    Args:
-        path (str): The path where the file will be saved.
-        data (list[dict]): The list of NOMAD entry dicts to be written to the file.
-    """
-    if not path.endswith('parquet'):
-        raise ValueError('Unsupported file format. Please use parquet.')
-
-    table: pa.Table = archives_to_arrow_table(data, logger)
-    with pq.ParquetWriter(
-        path,
-        table.schema,
-        compression='snappy',  # snappy for faster write/read for individual files
-        use_dictionary=True,
-    ) as writer:
-        writer.write_table(table)
-
-    return table.num_rows
-
-
-def write_json_file(path: str, data, logger=None):
-    """Writes a JSON file with the given data.
-
-    Args:
-        path (str): The path where the file will be saved.
-        data (list[dict]): The list of NOMAD entry dicts to be written to the file.
-    """
-    if not path.endswith('json'):
-        raise ValueError('Unsupported file format. Please use json.')
-
-    with open(path, 'w', encoding='utf-8') as f:
-        json.dump(data, f, indent=2)
-
-    return len(data)
-
-
-def merge_files(
-    input_file_paths: list[str], output_file_format: str, output_file_path: str
-):
-    """Merges multiple Parquet or JSON files into a single file.
-
-    Args:
-        input_file_paths (list[str]): List of file paths to be merged.
-        output_file_format (str): The format of the output file ('parquet', 'csv', or
-            'json').
-        output_file_path (str): Path of the merged output file.
-    """
-    if output_file_format == 'parquet':
-        # Creates a logical dataset from the input files, not loading all data into
-        # memory. Also, unifies the schema across the files.
-        dataset = ds.dataset(input_file_paths, format='parquet')
-
-        # Write the dataset to a single Parquet file in batches
-        with pq.ParquetWriter(
-            output_file_path,
-            dataset.schema,
-            compression='zstd',  # for better compression for merged file
-            compression_level=3,
-            use_dictionary=True,
-        ) as writer:
-            for batch in dataset.to_batches():
-                writer.write_batch(batch)
-
-    elif output_file_format == 'csv':
-        # Creates a logical dataset from the input files, not loading all data into
-        # memory. Also, unifies the schema across the files.
-        # The batch files for `csv` are written in Parquet format for efficiency,
-        # so we read them as Parquet here.
-        dataset = ds.dataset(input_file_paths, format='parquet')
-
-        # PyArrow CSV writer doesn't support nested types (list, struct, etc.)
-        # Convert nested columns to JSON strings
-        csv_schema = _get_csv_compatible_schema(dataset.schema)
-
-        # Write the dataset to a single CSV file in batches
-        with pcsv.CSVWriter(output_file_path, csv_schema) as writer:
-            for batch in dataset.to_batches():
-                csv_batch = _stringify_nested_columns(batch, csv_schema=csv_schema)
-                writer.write_batch(csv_batch)
-
-    elif output_file_format == 'json':
-
-        def _json_stream_files(input_file_paths):
-            """Generator that streams one entry dict at a time from multiple files."""
-            for file_path in input_file_paths:
-                with open(file_path, encoding='utf-8') as f:
-                    data = json_stream.load(f)
-                    yield from data
-
-        # Write a single JSON file by streaming entry dicts and wrapping in a list
-        with open(output_file_path, 'w', encoding='utf-8') as f:
-            f.write('[\n')
-            first_item = True
-            for item in _json_stream_files(input_file_paths):
-                if not first_item:
-                    f.write(',\n')
-                # Convert transient json_stream object to standard Python types
-                json.dump(json_stream.to_standard_types(item), f, indent=4)
-                first_item = False
-            f.write('\n]')
-
-    else:
-        raise ValueError('Unsupported file format. Please use parquet, csv, or json.')
 
 
 def generate_archives(

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -700,18 +700,19 @@ def generate_archives(
         for entry_id in entry_ids:
             entry = {'entry_id': entry_id, 'upload_id': upload_id}
             try:
-                with upload_files.read_archive(entry_id) as archive:
+                with upload_files.read_archive(entry_id) as upload_archive:
                     entry['archive'] = required_reader.read(
-                        archive, entry_id, upload_id
+                        upload_archive, entry_id, upload_id
                     )
                     yield entry
             except Exception as e:
-                logger.error(
-                    'failed to read entry archive',
-                    entry_id=entry_id,
-                    upload_id=upload_id,
-                    exc_info=e,
-                )
+                if logger:
+                    logger.error(
+                        'failed to read entry archive',
+                        entry_id=entry_id,
+                        upload_id=upload_id,
+                        exc_info=e,
+                    )
 
 
 def generate_table_rows(
@@ -741,7 +742,7 @@ def write_dicts_to_json(items: Iterable[dict], output_file_path: str) -> int:
         for item in items:
             if not first_item:
                 f.write(',\n')
-            json.dump(item, f, indent=2)
+            json.dump(item, f, separators=(',', ':'))
             count += 1
             first_item = False
 
@@ -761,15 +762,14 @@ def write_table_rows_to_json(
         file.write('[\n')
 
         for row, row_column_defs in rows_with_definitions:
-            # Accumulate only the schema information.
+            # accumulate only the schema information
             for column, quantity_def in row_column_defs.items():
                 columns_quantity_def.setdefault(column, quantity_def)
 
-            # Write the current row immediately.
+            # write the current row immediately
             if not first_row:
                 file.write(',\n')
-
-            json.dump(row, file, indent=2)
+            json.dump(row, file, separators=(',', ':'))
             first_row = False
 
         file.write('\n]')

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import lru_cache
+from typing import Any
 
 from nomad.app.v1.models.models import User
 from nomad.archive.required import RequiredReader
@@ -423,7 +424,9 @@ def _stringify_nested_columns(
 def generate_archives(
     manifest: list[ManifestEntry], required: dict | str, user_id: str, logger=None
 ) -> Iterable[dict]:
-    """Generates entry archive dicts from the manifest and required fields."""
+    """
+    Yields entry archive dict using the manifest and required fields one at a time.
+    """
 
     # set up required reader
     required_reader = RequiredReader(
@@ -471,7 +474,7 @@ def generate_table_rows(
     manifest: list[ManifestEntry], required: dict | str, user_id: str, logger=None
 ) -> Iterable[FlatEntryArchive]:
     """
-    Generates table rows from the manifest and required fields.
+    Yields table row using the manifest and required fields one at a time.
     """
     archives = generate_archives(manifest, required, user_id, logger)
 
@@ -522,14 +525,22 @@ def write_dicts_to_json(items: Iterable[dict], output_file_path: str) -> int:
 
 
 def write_table_rows_to_ndjson(
-    table_rows: Iterable[FlatEntryArchive], output_file_path: str
+    manifest: list[ManifestEntry],
+    required: str | dict[str, Any],
+    user_id: str,
+    output_file_path: str,
+    logger=None,
 ) -> dict[str, Quantity]:
     if not output_file_path.endswith('.ndjson'):
         raise ValueError('ouput_file_path should have .ndjson extension.')
     columns_quantity_def: dict[str, Quantity] = {}
 
+    table_rows_with_columns_quantity_def = generate_table_rows(
+        manifest, required, user_id, logger
+    )
+
     with open(output_file_path, 'w', encoding='utf-8') as file:
-        for table_row in table_rows:
+        for table_row in table_rows_with_columns_quantity_def:
             # accumulate only the schema information
             for column, quantity_def in table_row.columns_quantity_def.items():
                 columns_quantity_def.setdefault(column, quantity_def)

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -354,7 +354,10 @@ def archive_to_row(archive: dict) -> tuple[dict, dict[str, Quantity]]:
 
     columns_quantity_def: dict[str, Quantity] = {}
     context = _FlattenEntryContext(
-        row={'entry_id': archive['entry_id']},  # Always include entry_id as a column
+        row={
+            'entry_id': archive['entry_id'],
+            'upload_id': archive['upload_id'],
+        },  # Always include entry_id and upload_id as columns
         columns_quantity_def=columns_quantity_def,
         unhandled_keys=[],
     )
@@ -454,8 +457,10 @@ def _archives_to_rows(  # noqa: PLR0912
 
 
 def _ordered_columns(columns) -> list[str]:
-    """Put entry_id first and sort all remaining columns alphabetically."""
-    return sorted(columns, key=lambda column: (column != 'entry_id', column))
+    """Put entry_id and upload_id first and sort all remaining columns alphabetically."""
+    return sorted(
+        columns, key=lambda column: (column != ['entry_id', 'upload_id'], column)
+    )
 
 
 def archives_to_dataframe(archives: list[dict] | dict, logger=None) -> pd.DataFrame:

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -488,16 +488,18 @@ def generate_table_rows(
             all_unhandled_keys.update(table_row.unhandled_keys)
             yield table_row
         except Exception as e:
-            logger.error(
-                'failed to flatten archive '
-                f'(entry_id={entry_id} upload_id={upload_id})',
-                exc_info=e,
-            )
+            if logger:
+                logger.error(
+                    'failed to flatten archive '
+                    f'(entry_id={entry_id} upload_id={upload_id})',
+                    exc_info=e,
+                )
     if all_unhandled_keys and logger:
-        logger.warning(
-            f'Unhandled keys ({len(all_unhandled_keys)}) while flattening '
-            f'archives: {all_unhandled_keys}'
-        )
+        if logger:
+            logger.warning(
+                f'Unhandled keys ({len(all_unhandled_keys)}) while flattening '
+                f'archives: {all_unhandled_keys}'
+            )
 
 
 def write_dicts_to_json(items: Iterable[dict], output_file_path: str) -> int:

--- a/src/nomad_ml_workflows/actions/export_entries/utils.py
+++ b/src/nomad_ml_workflows/actions/export_entries/utils.py
@@ -588,7 +588,6 @@ def _stringify_nested_columns(
     new_columns = []
     for i, column in enumerate(batch.columns):
         if _is_nested_type(batch.schema.field(i).type):
-            # Convert each element to JSON string
             stringified = pa.array(
                 [
                     json.dumps(value, separators=(',', ':'))
@@ -793,28 +792,23 @@ def write_dicts_to_json(items: Iterable[dict], output_file_path: str) -> int:
     return count
 
 
-def write_table_rows_to_json(
+def write_table_rows_to_ndjson(
     rows_with_definitions: Iterable[tuple[dict, dict[str, Quantity]]],
     output_file_path: str,
 ) -> dict[str, Quantity]:
+    if not output_file_path.endswith('.ndjson')
+        raise ValueError('ouput_file_path should have .ndjson extension.')
     columns_quantity_def: dict[str, Quantity] = {}
-    first_row = True
 
     with open(output_file_path, 'w', encoding='utf-8') as file:
-        file.write('[\n')
-
         for row, row_column_defs in rows_with_definitions:
             # accumulate only the schema information
             for column, quantity_def in row_column_defs.items():
                 columns_quantity_def.setdefault(column, quantity_def)
 
             # write the current row immediately
-            if not first_row:
-                file.write(',\n')
             json.dump(row, file, separators=(',', ':'))
-            first_row = False
-
-        file.write('\n]')
+            file.write('\n')
 
     return columns_quantity_def
 
@@ -857,7 +851,7 @@ def write_table_rows_to_tabular_file(
     logger=None,
 ) -> int:
     """
-    Stream flattened rows from JSON into byte-bounded Parquet or CSV batches.
+    Stream flattened rows from NDJSON into byte-bounded Parquet or CSV batches.
 
     The complete set of quantity definitions is collected before this function is
     called, allowing each row to be normalized once into a RecordBatch with the same
@@ -906,8 +900,8 @@ def write_table_rows_to_tabular_file(
             buffered_batches.clear()
             buffered_bytes = 0
 
-        for row in json_stream.load(input_file):
-            standard_row = json_stream.to_standard_types(row)
+        for line in input_file:
+            standard_row = json.loads(line)
             if not isinstance(standard_row, dict):
                 raise ValueError('Each table row must be a JSON object.')
             row_batch = _table_rows_to_arrow_batch(

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -25,8 +25,6 @@ with workflow.unsafe.imports_passed_through():
         NormalizedSearchSettings,
         OutputFile,
         PrepareManifestInput,
-        ReadArchivesAndWriteOutputJsonInput,
-        ReadArchivesAndWriteTableRowsInput,
         ReadArchivesWorkflowInput,
     )
 
@@ -44,12 +42,7 @@ class ReadArchivesWorkflow:
         if data.output_file_format == 'json':
             return await workflow.execute_activity(
                 read_archives_and_write_output_json,
-                ReadArchivesAndWriteOutputJsonInput(
-                    user_id=data.user_id,
-                    manifest_path=data.manifest_file_path,
-                    required=data.required,
-                    output_file_path=f'{data.artifact_subdirectory}/data.{data.output_file_format}',
-                ),
+                data,
                 start_to_close_timeout=timedelta(hours=2),
                 retry_policy=retry_policy,
             )
@@ -57,13 +50,7 @@ class ReadArchivesWorkflow:
         # Write table rows and columns quantity definition files
         await workflow.execute_activity(
             read_archives_and_write_table_rows,
-            ReadArchivesAndWriteTableRowsInput(
-                user_id=data.user_id,
-                manifest_path=data.manifest_file_path,
-                required=data.required,
-                table_rows_file_path=f'{data.artifact_subdirectory}/table_rows.tmp.{data.output_file_format}',
-                columns_quantity_def_file_path=f'{data.artifact_subdirectory}/columns_quantity_def.tmp.{data.output_file_format}',
-            ),
+            data,
             start_to_close_timeout=timedelta(hours=2),
             retry_policy=retry_policy,
         )

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -59,8 +59,6 @@ class ReadArchivesWorkflow:
                 retry_policy=retry_policy,
             )
 
-        raise ValueError(f'Unsupported output file format: {data.output_file_format}')
-
 
 @workflow.defn
 class ExportEntriesWorkflow:
@@ -117,14 +115,21 @@ class ExportEntriesWorkflow:
                 retry_policy=retry_policy,
             )
 
-            for k in [
-                'num_entries_available',
-                'num_entries_selected',
-                'search_start_time',
-                'search_end_time',
-                'reached_max_entries_limit',
-            ]:
-                setattr(export_dataset_input.metadata, k, getattr(manifest_output, k))
+            export_dataset_input.metadata.num_entries_available = (
+                manifest_output.num_entries_available
+            )
+            export_dataset_input.metadata.num_entries_selected = (
+                manifest_output.num_entries_selected
+            )
+            export_dataset_input.metadata.search_start_time = (
+                manifest_output.search_start_time
+            )
+            export_dataset_input.metadata.search_end_time = (
+                manifest_output.search_end_time
+            )
+            export_dataset_input.metadata.reached_max_entries_limit = (
+                manifest_output.reached_max_entries_limit
+            )
             export_dataset_input.source_paths = [manifest_file_path]
 
             if manifest_output.num_entries_selected > 0:

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import timedelta
 
 from temporalio import workflow
@@ -6,54 +5,66 @@ from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
 
 with workflow.unsafe.imports_passed_through():
-    from nomad.app.v1.models.models import MetadataPagination
     from nomad.config import config as nomad_config
 
     from nomad_ml_workflows.actions.export_entries.activities import (
         cleanup_artifacts,
-        collect_page_cursors,
         create_artifact_subdirectory,
         export_dataset_to_upload,
-        merge_output_files,
-        read_archives,
-        rename_generated_file,
+        prepare_manifest,
+        read_archives_and_write_output_json,
+        read_archives_and_write_table_rows,
     )
     from nomad_ml_workflows.actions.export_entries.models import (
         CleanupArtifactsInput,
-        CollectCursorsInput,
         CreateArtifactSubdirectoryInput,
         ExportDatasetInput,
         ExportDatasetMetadata,
         ExportEntriesOutput,
         ExportEntriesUserInput,
-        MergeOutputFilesInput,
-        RenameGeneratedFileInput,
-        SearchPageInput,
-        SearchPageOutput,
+        NormalizedSearchSettings,
+        OutputFile,
+        PrepareManifestInput,
+        ReadArchivesAndWriteOutputJsonInput,
+        ReadArchivesAndWriteTableRowsInput,
+        ReadArchivesWorkflowInput,
     )
 
 
 @workflow.defn
-class SearchPageWorkflow:
+class ReadArchivesWorkflow:
     """
-    Child workflow that executes a single search page activity.
-
-    Each instance handles one page of results, identified by its
-    page_after_value cursor. Running multiple instances concurrently
-    via the parent workflow achieves parallel page fetching.
+    Child workflow that reads an archive and writes the output file.
     """
 
     @workflow.run
-    async def run(self, data: SearchPageInput) -> SearchPageOutput:
-        config = nomad_config.get_plugin_entry_point(
-            'nomad_ml_workflows.actions:export_entries'
-        )
+    async def run(self, data: ReadArchivesWorkflowInput) -> OutputFile:
         retry_policy = RetryPolicy(maximum_attempts=1)
 
-        return await workflow.execute_activity(
-            read_archives,
-            data,
-            start_to_close_timeout=timedelta(seconds=config.search_batch_timeout),
+        if data.output_file_format == 'json':
+            return await workflow.execute_activity(
+                read_archives_and_write_output_json,
+                ReadArchivesAndWriteOutputJsonInput(
+                    user_id=data.user_id,
+                    manifest_path=data.manifest_file_path,
+                    required=data.required,
+                    output_file_path=f'{data.artifact_subdirectory}/data.{data.output_file_format}',
+                ),
+                start_to_close_timeout=timedelta(hours=2),
+                retry_policy=retry_policy,
+            )
+
+        # Write table rows and columns quantity definition files
+        await workflow.execute_activity(
+            read_archives_and_write_table_rows,
+            ReadArchivesAndWriteTableRowsInput(
+                user_id=data.user_id,
+                manifest_path=data.manifest_file_path,
+                required=data.required,
+                table_rows_file_path=f'{data.artifact_subdirectory}/table_rows.tmp.{data.output_file_format}',
+                columns_quantity_def_file_path=f'{data.artifact_subdirectory}/columns_quantity_def.tmp.{data.output_file_format}',
+            ),
+            start_to_close_timeout=timedelta(hours=2),
             retry_policy=retry_policy,
         )
 
@@ -92,8 +103,8 @@ class ExportEntriesWorkflow:
                 f'export_entries_{workflow.info().start_time.isoformat()}'
             ),
             zip_output=data.output_settings.zip_output,
-            source_path=None,
-            metadata=ExportDatasetMetadata(user_input=data),
+            source_paths=None,
+            metadata=ExportDatasetMetadata(user_input=data),  # type: ignore
         )
 
         try:
@@ -101,130 +112,61 @@ class ExportEntriesWorkflow:
                 'nomad_ml_workflows.actions:export_entries'
             )
 
-            # Build a representative SearchPageInput to resolve shared settings
-            # (query, owner, required, batch_file_format) once.
-            template_spi = SearchPageInput.from_user_input(
-                data,
-                page_num=0,
-                output_file_path='',  # placeholder, real paths are set per page below
-                max_entries_export_limit=config.max_entries_export_limit,
-            )
-            page_size = data.search_settings.page_size
+            search_settings = NormalizedSearchSettings.from_user_input(data)
 
-            # Collect all page cursors with a lightweight serial walk
-            cursors_output = await workflow.execute_activity(
-                collect_page_cursors,
-                CollectCursorsInput(
-                    user_id=data.user_id,
-                    owner=data.search_settings.owner,
-                    query=template_spi.query,
-                    page_size=page_size,
-                    max_entries_export_limit=config.max_entries_export_limit,
+            manifest_file_path = f'{artifact_subdirectory}/manifest.json'
+            manifest_output = await workflow.execute_activity(
+                prepare_manifest,
+                PrepareManifestInput(
+                    user_id=search_settings.user_id,
+                    owner=search_settings.owner,
+                    query=search_settings.query,
+                    pagination=search_settings.pagination,
+                    max_entries_export_limit=config.max_entries_export_limit,  # type: ignore
+                    manifest_file_path=manifest_file_path,
                 ),
                 start_to_close_timeout=timedelta(hours=2),
                 retry_policy=retry_policy,
             )
+
             export_dataset_input.metadata.reached_max_entries_limit = (
-                cursors_output.num_entries_available > config.max_entries_export_limit
+                manifest_output.num_entries_available > config.max_entries_export_limit  # type: ignore
             )
             export_dataset_input.metadata.num_entries_available = (
-                cursors_output.num_entries_available
+                manifest_output.num_entries_available
             )
-            if cursors_output.num_pages == 0:
+            if manifest_output.num_entries_available == 0:
                 # No pages to export, return early with an empty dataset
                 return ExportEntriesOutput(exported_dir_path='', workflow_duration=0.0)
 
-            # Build one SearchPageInput per page with the corresponding cursor and
-            # export limit for that page
-            search_page_inputs: list[SearchPageInput] = []
-            for page_iter, cursor in enumerate(cursors_output.page_after_values):
-                page_num = page_iter + 1
-                entries_so_far = page_iter * page_size
-                limit_for_page = min(
-                    page_size, config.max_entries_export_limit - entries_so_far
-                )
-                spi = template_spi.model_copy(
-                    update={
-                        'page_num': page_num,
-                        'output_file_path': (
-                            f'{artifact_subdirectory}/{page_num}'
-                            f'.{template_spi.batch_file_format}'
-                        ),
-                        'max_entries_export_limit': limit_for_page,
-                        'pagination': MetadataPagination(
-                            page_size=page_size,
-                            page_after_value=cursor,
-                        ),
-                    }
-                )
-                search_page_inputs.append(spi)
-
-            # Run child workflows for each page with bounded concurrency to avoid
-            # overwhelming the Temporal server with too many concurrent workflows.
-            search_page_outputs: list[SearchPageOutput] = []
-            for concurr_batch_start in range(
-                0, len(search_page_inputs), config.search_workflow_concurrency_limit
-            ):
-                concurr_batch_spis = search_page_inputs[
-                    concurr_batch_start : concurr_batch_start
-                    + config.search_workflow_concurrency_limit
-                ]
-                concurr_batch_spos = await asyncio.gather(
-                    *[
-                        workflow.execute_child_workflow(
-                            SearchPageWorkflow.run,
-                            spi,
-                            id=f'{workflow.info().workflow_id}-search-page-'
-                            f'{spi.page_num}',
-                            parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
-                            retry_policy=retry_policy,
-                        )
-                        for spi in concurr_batch_spis
-                    ]
-                )
-                search_page_outputs.extend(concurr_batch_spos)
-
-            # Pages ran concurrently so take the earliest start and latest end. ISO
-            # timestamp strings can be compared lexicographically
-            export_dataset_input.metadata.num_entries_exported = sum(
-                spo.num_entries_exported for spo in search_page_outputs
-            )
-            export_dataset_input.metadata.search_start_time = min(
-                [spo.search_start_time for spo in search_page_outputs]
-            )
-            export_dataset_input.metadata.search_end_time = max(
-                [spo.search_end_time for spo in search_page_outputs]
+            output_file: OutputFile = await workflow.execute_child_workflow(
+                ReadArchivesWorkflow.run,
+                ReadArchivesWorkflowInput(
+                    user_id=data.user_id,
+                    output_file_format=data.output_settings.output_file_format,
+                    manifest_file_path=manifest_file_path,
+                    artifact_subdirectory=artifact_subdirectory,
+                    required=search_settings.required,
+                ),
+                id=f'{workflow.info().workflow_id}-read-archives-and-write-file',
+                parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
+                retry_policy=retry_policy,
             )
 
-            # Merge batch files into one file to be exported
-            # Only include paths where entries were actually written to disk
-            generated_file_paths = [
-                search_page_inputs[i].output_file_path
-                for i, spo in enumerate(search_page_outputs)
-                if spo.num_entries_exported > 0
+            export_dataset_input.metadata.num_entries_exported = (
+                output_file.num_entries_exported
+            )
+            export_dataset_input.metadata.search_start_time = (
+                manifest_output.search_start_time
+            )
+            export_dataset_input.metadata.search_end_time = (
+                manifest_output.search_end_time
+            )
+
+            export_dataset_input.source_paths = [
+                manifest_file_path,
+                output_file.file_path,
             ]
-            if len(generated_file_paths) == 1:
-                export_dataset_input.source_path = await workflow.execute_activity(
-                    rename_generated_file,
-                    RenameGeneratedFileInput(
-                        artifact_subdirectory=artifact_subdirectory,
-                        output_file_format=data.output_settings.output_file_format,
-                        generated_file_path=generated_file_paths[0],
-                    ),
-                    start_to_close_timeout=timedelta(hours=2),
-                    retry_policy=retry_policy,
-                )
-            elif len(generated_file_paths) > 1:
-                export_dataset_input.source_path = await workflow.execute_activity(
-                    merge_output_files,
-                    MergeOutputFilesInput(
-                        artifact_subdirectory=artifact_subdirectory,
-                        output_file_format=data.output_settings.output_file_format,
-                        generated_file_paths=generated_file_paths,
-                    ),
-                    start_to_close_timeout=timedelta(hours=2),
-                    retry_policy=retry_policy,
-                )
 
         except Exception as e:
             # Capture error info to include in metadata

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -13,7 +13,7 @@ with workflow.unsafe.imports_passed_through():
         export_dataset_to_upload,
         prepare_manifest,
         read_archives_and_write_output_json,
-        read_archives_and_write_table_rows,
+        read_archives_and_write_output_tabular,
     )
     from nomad_ml_workflows.actions.export_entries.models import (
         CleanupArtifactsInput,
@@ -47,13 +47,15 @@ class ReadArchivesWorkflow:
                 retry_policy=retry_policy,
             )
 
-        # Write table rows and columns quantity definition files
-        await workflow.execute_activity(
-            read_archives_and_write_table_rows,
-            data,
-            start_to_close_timeout=timedelta(hours=2),
-            retry_policy=retry_policy,
-        )
+        if data.output_file_format in ['parquet', 'csv']:
+            return await workflow.execute_activity(
+                read_archives_and_write_output_tabular,
+                data,
+                start_to_close_timeout=timedelta(hours=2),
+                retry_policy=retry_policy,
+            )
+
+        raise ValueError(f'Unsupported output file format: {data.output_file_format}')
 
 
 @workflow.defn

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -96,7 +96,7 @@ class ExportEntriesWorkflow:
                 f'export_entries_{workflow.info().start_time.isoformat()}'
             ),
             zip_output=data.output_settings.zip_output,
-            source_paths=None,
+            source_paths=[],
             metadata=ExportDatasetMetadata(user_input=data),  # type: ignore
         )
 
@@ -117,47 +117,37 @@ class ExportEntriesWorkflow:
                 retry_policy=retry_policy,
             )
 
-            export_dataset_input.metadata.num_entries_available = (
-                manifest_output.num_entries_available
-            )
-            export_dataset_input.metadata.num_entries_selected = (
-                manifest_output.num_entries_selected
-            )
-            export_dataset_input.metadata.search_start_time = (
-                manifest_output.search_start_time
-            )
-            export_dataset_input.metadata.search_end_time = (
-                manifest_output.search_end_time
-            )
-            export_dataset_input.metadata.reached_max_entries_limit = (
-                manifest_output.reached_max_entries_limit
-            )
-            if manifest_output.num_entries_selected == 0:
-                # No pages to export, return early with an empty dataset
-                return ExportEntriesOutput(exported_dir_path='', workflow_duration=0.0)
+            for k in [
+                'num_entries_available',
+                'num_entries_selected',
+                'search_start_time',
+                'search_end_time',
+                'reached_max_entries_limit',
+            ]:
+                setattr(export_dataset_input.metadata, k, getattr(manifest_output, k))
+            export_dataset_input.source_paths = [manifest_file_path]
 
-            output_file: OutputFile = await workflow.execute_child_workflow(
-                ReadArchivesWorkflow.run,
-                ReadArchivesWorkflowInput(
-                    user_id=data.user_id,
-                    output_file_format=data.output_settings.output_file_format,
-                    manifest_file_path=manifest_file_path,
-                    artifact_subdirectory=artifact_subdirectory,
-                    required=search_settings.required,
-                ),
-                id=f'{workflow.info().workflow_id}-read-archives-and-write-file',
-                parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
-                retry_policy=retry_policy,
-            )
-
-            export_dataset_input.metadata.num_entries_exported = (
-                output_file.num_entries_exported
-            )
-
-            export_dataset_input.source_paths = [
-                manifest_file_path,
-                output_file.file_path,
-            ]
+            if manifest_output.num_entries_selected > 0:
+                output_file: OutputFile = await workflow.execute_child_workflow(
+                    ReadArchivesWorkflow.run,
+                    ReadArchivesWorkflowInput(
+                        user_id=data.user_id,
+                        output_file_format=data.output_settings.output_file_format,
+                        manifest_file_path=manifest_file_path,
+                        artifact_subdirectory=artifact_subdirectory,
+                        required=search_settings.required,
+                    ),
+                    id=f'{workflow.info().workflow_id}-read-archives-and-write-file',
+                    parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
+                    retry_policy=retry_policy,
+                )
+                export_dataset_input.metadata.num_entries_exported = (
+                    output_file.num_entries_exported
+                )
+                export_dataset_input.source_paths = [
+                    manifest_file_path,
+                    output_file.file_path,
+                ]
 
         except Exception as e:
             # Capture error info to include in metadata

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -120,6 +120,9 @@ class ExportEntriesWorkflow:
             export_dataset_input.metadata.num_entries_available = (
                 manifest_output.num_entries_available
             )
+            export_dataset_input.metadata.num_entries_selected = (
+                manifest_output.num_entries_selected
+            )
             export_dataset_input.metadata.search_start_time = (
                 manifest_output.search_start_time
             )
@@ -129,7 +132,7 @@ class ExportEntriesWorkflow:
             export_dataset_input.metadata.reached_max_entries_limit = (
                 manifest_output.reached_max_entries_limit
             )
-            if manifest_output.num_entries_available == 0:
+            if manifest_output.num_entries_selected == 0:
                 # No pages to export, return early with an empty dataset
                 return ExportEntriesOutput(exported_dir_path='', workflow_duration=0.0)
 

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -16,6 +16,7 @@ with workflow.unsafe.imports_passed_through():
         export_dataset_to_upload,
         merge_output_files,
         read_archives,
+        rename_generated_file,
     )
     from nomad_ml_workflows.actions.export_entries.models import (
         CleanupArtifactsInput,
@@ -26,6 +27,7 @@ with workflow.unsafe.imports_passed_through():
         ExportEntriesOutput,
         ExportEntriesUserInput,
         MergeOutputFilesInput,
+        RenameGeneratedFileInput,
         SearchPageInput,
         SearchPageOutput,
     )
@@ -90,7 +92,7 @@ class ExportEntriesWorkflow:
                 f'export_entries_{workflow.info().start_time.isoformat()}'
             ),
             zip_output=data.output_settings.zip_output,
-            source_paths=[],
+            source_path=None,
             metadata=ExportDatasetMetadata(user_input=data),
         )
 
@@ -201,8 +203,19 @@ class ExportEntriesWorkflow:
                 for i, spo in enumerate(search_page_outputs)
                 if spo.num_entries_exported > 0
             ]
-            if generated_file_paths:
-                merged_file_path = await workflow.execute_activity(
+            if len(generated_file_paths) == 1:
+                export_dataset_input.source_path = await workflow.execute_activity(
+                    rename_generated_file,
+                    RenameGeneratedFileInput(
+                        artifact_subdirectory=artifact_subdirectory,
+                        output_file_format=data.output_settings.output_file_format,
+                        generated_file_path=generated_file_paths[0],
+                    ),
+                    start_to_close_timeout=timedelta(hours=2),
+                    retry_policy=retry_policy,
+                )
+            elif len(generated_file_paths) > 1:
+                export_dataset_input.source_path = await workflow.execute_activity(
                     merge_output_files,
                     MergeOutputFilesInput(
                         artifact_subdirectory=artifact_subdirectory,
@@ -212,7 +225,6 @@ class ExportEntriesWorkflow:
                     start_to_close_timeout=timedelta(hours=2),
                     retry_policy=retry_policy,
                 )
-                export_dataset_input.source_paths = [merged_file_path]
 
         except Exception as e:
             # Capture error info to include in metadata

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -117,11 +117,17 @@ class ExportEntriesWorkflow:
                 retry_policy=retry_policy,
             )
 
-            export_dataset_input.metadata.reached_max_entries_limit = (
-                manifest_output.reached_max_entries_limit
-            )
             export_dataset_input.metadata.num_entries_available = (
                 manifest_output.num_entries_available
+            )
+            export_dataset_input.metadata.search_start_time = (
+                manifest_output.search_start_time
+            )
+            export_dataset_input.metadata.search_end_time = (
+                manifest_output.search_end_time
+            )
+            export_dataset_input.metadata.reached_max_entries_limit = (
+                manifest_output.reached_max_entries_limit
             )
             if manifest_output.num_entries_available == 0:
                 # No pages to export, return early with an empty dataset
@@ -143,12 +149,6 @@ class ExportEntriesWorkflow:
 
             export_dataset_input.metadata.num_entries_exported = (
                 output_file.num_entries_exported
-            )
-            export_dataset_input.metadata.search_start_time = (
-                manifest_output.search_start_time
-            )
-            export_dataset_input.metadata.search_end_time = (
-                manifest_output.search_end_time
             )
 
             export_dataset_input.source_paths = [

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -28,6 +28,10 @@ with workflow.unsafe.imports_passed_through():
         ReadArchivesWorkflowInput,
     )
 
+config = nomad_config.get_plugin_entry_point(
+    'nomad_ml_workflows.actions:export_entries'
+)
+
 
 @workflow.defn
 class ReadArchivesWorkflow:
@@ -43,7 +47,7 @@ class ReadArchivesWorkflow:
             return await workflow.execute_activity(
                 read_archives_and_write_output_json,
                 data,
-                start_to_close_timeout=timedelta(hours=2),
+                start_to_close_timeout=timedelta(seconds=config.read_archives_timeout),  # type: ignore
                 retry_policy=retry_policy,
             )
 
@@ -51,7 +55,7 @@ class ReadArchivesWorkflow:
             return await workflow.execute_activity(
                 read_archives_and_write_output_tabular,
                 data,
-                start_to_close_timeout=timedelta(hours=2),
+                start_to_close_timeout=timedelta(seconds=config.read_archives_timeout),  # type: ignore
                 retry_policy=retry_policy,
             )
 
@@ -97,10 +101,6 @@ class ExportEntriesWorkflow:
         )
 
         try:
-            config = nomad_config.get_plugin_entry_point(
-                'nomad_ml_workflows.actions:export_entries'
-            )
-
             search_settings = NormalizedSearchSettings.from_user_input(data)
 
             manifest_file_path = f'{artifact_subdirectory}/manifest.json'
@@ -110,8 +110,7 @@ class ExportEntriesWorkflow:
                     user_id=search_settings.user_id,
                     owner=search_settings.owner,
                     query=search_settings.query,
-                    pagination=search_settings.pagination,
-                    max_entries_export_limit=config.max_entries_export_limit,  # type: ignore
+                    num_entries_user_limit=search_settings.num_entries_user_limit,  # type: ignore
                     manifest_file_path=manifest_file_path,
                 ),
                 start_to_close_timeout=timedelta(hours=2),
@@ -119,7 +118,7 @@ class ExportEntriesWorkflow:
             )
 
             export_dataset_input.metadata.reached_max_entries_limit = (
-                manifest_output.num_entries_available > config.max_entries_export_limit  # type: ignore
+                manifest_output.reached_max_entries_limit
             )
             export_dataset_input.metadata.num_entries_available = (
                 manifest_output.num_entries_available

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -103,7 +103,7 @@ class ExportEntriesWorkflow:
         try:
             search_settings = NormalizedSearchSettings.from_user_input(data)
 
-            manifest_file_path = f'{artifact_subdirectory}/manifest.json'
+            manifest_file_path = f'{artifact_subdirectory}/selected_entries.json'
             manifest_output = await workflow.execute_activity(
                 prepare_manifest,
                 PrepareManifestInput(

--- a/tests/actions/export_entries/test_models.py
+++ b/tests/actions/export_entries/test_models.py
@@ -1,18 +1,18 @@
 from nomad_ml_workflows.actions.export_entries.models import (
     Exclude,
     Include,
-    SearchPageInput,
+    NormalizedSearchSettings,
 )
 
 
 def test_build_archive_required_returns_wildcard_for_empty_paths():
-    assert SearchPageInput.build_archive_required(None) == '*'
+    assert NormalizedSearchSettings.build_archive_required(None) == '*'
 
 
 def test_build_archive_required_builds_nested_include_tree():
     required = [Include(path='data.results.energy', resolve_references=False)]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         'data': {'results': {'energy': 'include'}}
     }
 
@@ -23,13 +23,15 @@ def test_build_archive_required_prefers_parent_include():
         Include(path='data.results', resolve_references=False),
     ]
 
-    assert SearchPageInput.build_archive_required(required) == {'data': 'include'}
+    assert NormalizedSearchSettings.build_archive_required(required) == {
+        'data': 'include'
+    }
 
 
 def test_build_archive_required_strips_include_wildcard_suffix():
     required = [Include(path='data.results*', resolve_references=False)]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         'data': {'results': 'include'}
     }
 
@@ -37,7 +39,7 @@ def test_build_archive_required_strips_include_wildcard_suffix():
 def test_build_archive_required_builds_include_resolved_directive():
     required = [Include(path='data.results.energy', resolve_references=True)]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         'data': {'results': {'energy': 'include-resolved'}}
     }
 
@@ -48,7 +50,7 @@ def test_build_archive_required_prefers_include_resolved_for_same_path():
         Include(path='data.results.energy', resolve_references=True),
     ]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         'data': {'results': {'energy': 'include-resolved'}}
     }
 
@@ -56,7 +58,7 @@ def test_build_archive_required_prefers_include_resolved_for_same_path():
 def test_build_archive_required_exclude():
     required = [Exclude(path='data.results.energy')]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         '*': 'include',
         'data': {'results': {'energy': 'exclude'}},
     }
@@ -68,7 +70,7 @@ def test_build_archive_required_exclude_over_include():
         Exclude(path='data.results.energy'),
     ]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         '*': 'include',
         'data': {'results': {'energy': 'exclude'}},
     }
@@ -80,7 +82,7 @@ def test_build_archive_required_include_nested_exclude():
         Exclude(path='data.results.energy'),
     ]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         'data': {
             '*': 'include',
             'results': {'energy': 'exclude'},
@@ -94,7 +96,7 @@ def test_build_archive_required_include_resolved_nested_exclude():
         Exclude(path='data.results.energy'),
     ]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         'data': {
             '*': 'include-resolved',
             'results': {'energy': 'exclude'},
@@ -109,7 +111,7 @@ def test_build_archive_required_same_path_multiple_times():
         Exclude(path='data.results.energy'),
     ]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         '*': 'include',
         'data': {'results': {'energy': 'exclude'}},
     }
@@ -131,6 +133,6 @@ def test_build_archive_required_prefers_include_resolved_for_whole_parent():
         Include(path='data.results.energy', resolve_references=True),
     ]
 
-    assert SearchPageInput.build_archive_required(required) == {
+    assert NormalizedSearchSettings.build_archive_required(required) == {
         'data': 'include-resolved'
     }

--- a/tests/actions/export_entries/test_utils.py
+++ b/tests/actions/export_entries/test_utils.py
@@ -55,6 +55,35 @@ def _column(name: str, section=TypedEntryData) -> str:
     return f'data.{name}#{section.m_def.qualified_name()}'
 
 
+def _archives_to_arrow_table(archives: list[dict]) -> pa.Table:
+    table_rows = [
+        utils._flatten_entry_archive(
+            archive['archive'],
+            entry_id=archive['entry_id'],
+            upload_id=archive.get('upload_id', ''),
+        )
+        for archive in archives
+    ]
+    columns_quantity_def = {
+        column: quantity_def
+        for table_row in table_rows
+        for column, quantity_def in table_row.columns_quantity_def.items()
+    }
+    column_configs = utils._table_column_configs(columns_quantity_def)
+    schema = pa.schema(
+        [
+            pa.field(column_name, config.arrow_type)
+            for column_name, config in column_configs.items()
+        ]
+    )
+    batch = utils._table_rows_to_arrow_batch(
+        [table_row.data_dict for table_row in table_rows],
+        column_configs,
+        schema,
+    )
+    return pa.Table.from_batches([batch], schema=schema)
+
+
 def test_ordered_columns_places_identifiers_before_sorted_columns():
     assert utils._ordered_columns(
         ['z_column', 'upload_id', 'a_column', 'entry_id']
@@ -110,8 +139,8 @@ def test_is_list_of_string_for_supported_arrow_types(
     assert utils._is_list_of_string(arrow_type) is (is_string and list_depth > 0)
 
 
-def test_archives_to_arrow_table_uses_nomad_quantity_types(resolve_test_schema):
-    table = utils.archives_to_arrow_table(
+def test_table_rows_to_arrow_batch_uses_nomad_quantity_types(resolve_test_schema):
+    table = _archives_to_arrow_table(
         [
             _archive(
                 'entry_1',
@@ -193,39 +222,100 @@ def test_archives_to_arrow_table_uses_nomad_quantity_types(resolve_test_schema):
         ('str_matrix', ['one', ['two']]),
     ],
 )
-def test_archives_to_arrow_table_handles_invalid_list_shapes_with_None(
+def test_table_rows_to_arrow_batch_handles_invalid_list_shapes_with_none(
     resolve_test_schema,
     quantity_name,
     value,
 ):
-    table = utils.archives_to_arrow_table([_archive('entry_1', {quantity_name: value})])
-    assert table.column_names == ['entry_id', _column(quantity_name)]
+    table = _archives_to_arrow_table([_archive('entry_1', {quantity_name: value})])
+    assert table.column_names == ['entry_id', 'upload_id', _column(quantity_name)]
     assert table[_column(quantity_name)].to_pylist() == [None]
 
 
-def test_archives_to_arrow_table_handles_failed_conversion_with_None(
+def test_table_rows_to_arrow_batch_handles_failed_conversion_with_none(
     resolve_test_schema,
 ):
-    table = utils.archives_to_arrow_table(
-        [_archive('entry_1', {'count': 'not-an-integer'})]
-    )
+    table = _archives_to_arrow_table([_archive('entry_1', {'count': 'not-an-integer'})])
     assert table[_column('count')].to_pylist() == [None]
 
 
-def test_archives_to_dataframe_preserves_existing_behavior(resolve_test_schema):
-    dataframe = utils.archives_to_dataframe([_archive('entry_1', {'count': '7'})])
-
-    assert dataframe[_column('count')].iloc[0] == '7'
-
-
-def test_write_parquet_file_uses_schema_normalized_table(tmp_path, resolve_test_schema):
+def test_write_table_rows_to_tabular_file_uses_normalized_schema(
+    tmp_path,
+    resolve_test_schema,
+):
+    rows_path = tmp_path / 'entries.ndjson'
     output_path = tmp_path / 'entries.parquet'
+    table_rows = [
+        utils._flatten_entry_archive(
+            archive['archive'],
+            entry_id=archive['entry_id'],
+        )
+        for archive in [
+            _archive('entry_1', {'count': None}),
+            _archive('entry_2', {'count': '7'}),
+        ]
+    ]
+    columns_quantity_def = utils.write_table_rows_to_ndjson(
+        table_rows,
+        str(rows_path),
+    )
 
-    utils.write_parquet_file(
+    count = utils.write_table_rows_to_tabular_file(
+        str(rows_path),
         str(output_path),
-        [_archive('entry_1', {'count': None}), _archive('entry_2', {'count': '7'})],
+        columns_quantity_def,
     )
 
     table = pq.read_table(output_path)
+    assert count == len(table_rows)
     assert table.schema.field(_column('count')).type == pa.int32()
     assert table[_column('count')].to_pylist() == [None, 7]
+
+
+def test_write_table_rows_to_ndjson_accepts_repeated_quantity_definition(tmp_path):
+    output_path = tmp_path / 'rows.ndjson'
+    quantity_def = Quantity(type=str)
+
+    result = utils.write_table_rows_to_ndjson(
+        [
+            utils.FlatEntryArchive(
+                data_dict={'entry_id': 'one'},
+                columns_quantity_def={'value': quantity_def},
+                unhandled_keys=[],
+            ),
+            utils.FlatEntryArchive(
+                data_dict={'entry_id': 'two'},
+                columns_quantity_def={'value': quantity_def},
+                unhandled_keys=[],
+            ),
+        ],
+        str(output_path),
+    )
+
+    assert result == {'value': quantity_def}
+    assert output_path.read_text(encoding='utf-8') == (
+        '{"entry_id":"one"}\n{"entry_id":"two"}\n'
+    )
+
+
+def test_write_table_rows_to_tabular_file_reads_ndjson(tmp_path):
+    rows_path = tmp_path / 'rows.ndjson'
+    output_path = tmp_path / 'rows.parquet'
+    quantity_def = Quantity(type=str)
+    rows_path.write_text(
+        '{"entry_id":"one","upload_id":"upload","value":"first"}\n'
+        '{"entry_id":"two","upload_id":"upload","value":"second"}\n',
+        encoding='utf-8',
+    )
+
+    count = utils.write_table_rows_to_tabular_file(
+        str(rows_path),
+        str(output_path),
+        {'value': quantity_def},
+    )
+
+    table = pq.read_table(output_path)
+    assert count == table.num_rows
+    assert table.column_names == ['entry_id', 'upload_id', 'value']
+    assert table['entry_id'].to_pylist() == ['one', 'two']
+    assert table['value'].to_pylist() == ['first', 'second']

--- a/tests/actions/export_entries/test_utils.py
+++ b/tests/actions/export_entries/test_utils.py
@@ -242,6 +242,7 @@ def test_table_rows_to_arrow_batch_handles_failed_conversion_with_none(
 def test_write_table_rows_to_tabular_file_uses_normalized_schema(
     tmp_path,
     resolve_test_schema,
+    monkeypatch,
 ):
     rows_path = tmp_path / 'entries.ndjson'
     output_path = tmp_path / 'entries.parquet'
@@ -255,9 +256,9 @@ def test_write_table_rows_to_tabular_file_uses_normalized_schema(
             _archive('entry_2', {'count': '7'}),
         ]
     ]
+    monkeypatch.setattr(utils, 'generate_table_rows', lambda *_: iter(table_rows))
     columns_quantity_def = utils.write_table_rows_to_ndjson(
-        table_rows,
-        str(rows_path),
+        [], {}, 'user_id', str(rows_path)
     )
 
     count = utils.write_table_rows_to_tabular_file(
@@ -272,25 +273,26 @@ def test_write_table_rows_to_tabular_file_uses_normalized_schema(
     assert table[_column('count')].to_pylist() == [None, 7]
 
 
-def test_write_table_rows_to_ndjson_accepts_repeated_quantity_definition(tmp_path):
+def test_write_table_rows_to_ndjson_accepts_repeated_quantity_definition(
+    tmp_path, monkeypatch
+):
     output_path = tmp_path / 'rows.ndjson'
     quantity_def = Quantity(type=str)
+    table_rows = [
+        utils.FlatEntryArchive(
+            data_dict={'entry_id': 'one'},
+            columns_quantity_def={'value': quantity_def},
+            unhandled_keys=[],
+        ),
+        utils.FlatEntryArchive(
+            data_dict={'entry_id': 'two'},
+            columns_quantity_def={'value': quantity_def},
+            unhandled_keys=[],
+        ),
+    ]
+    monkeypatch.setattr(utils, 'generate_table_rows', lambda *_: iter(table_rows))
 
-    result = utils.write_table_rows_to_ndjson(
-        [
-            utils.FlatEntryArchive(
-                data_dict={'entry_id': 'one'},
-                columns_quantity_def={'value': quantity_def},
-                unhandled_keys=[],
-            ),
-            utils.FlatEntryArchive(
-                data_dict={'entry_id': 'two'},
-                columns_quantity_def={'value': quantity_def},
-                unhandled_keys=[],
-            ),
-        ],
-        str(output_path),
-    )
+    result = utils.write_table_rows_to_ndjson([], {}, 'user_id', str(output_path))
 
     assert result == {'value': quantity_def}
     assert output_path.read_text(encoding='utf-8') == (

--- a/tests/actions/export_entries/test_utils.py
+++ b/tests/actions/export_entries/test_utils.py
@@ -55,6 +55,29 @@ def _column(name: str, section=TypedEntryData) -> str:
     return f'data.{name}#{section.m_def.qualified_name()}'
 
 
+def test_ordered_columns_places_identifiers_before_sorted_columns():
+    assert utils._ordered_columns(
+        ['z_column', 'upload_id', 'a_column', 'entry_id']
+    ) == ['entry_id', 'upload_id', 'a_column', 'z_column']
+    assert utils._ordered_columns(['z_column', 'entry_id', 'a_column']) == [
+        'entry_id',
+        'a_column',
+        'z_column',
+    ]
+    assert utils._ordered_columns(['z_column', 'entry_id', 'a_column']) == [
+        'entry_id',
+        'a_column',
+        'z_column',
+    ]
+    assert utils._ordered_columns(
+        {'z_column': 'm_def_1', 'entry_id': 'str', 'a_column': 'm_def_2'}
+    ) == [
+        'entry_id',
+        'a_column',
+        'z_column',
+    ]
+
+
 @pytest.fixture
 def resolve_test_schema(monkeypatch):
     monkeypatch.setattr(


### PR DESCRIPTION
Refactor the Export Entries action from a concurrent, page-oriented pipeline into a manifest-driven streaming archive export.

Key changes:

- Search once and persist the selected `entry_id`/`upload_id` pairs in the user-facing `selected_entries.json` file.
- Replace per-page child workflows and batch merging with one archive-reading child workflow and one final output file.
- Stream JSON archives directly to disk.
- Add a two-pass tabular pipeline using temporary NDJSON for global schema discovery.
- Write byte-bounded Parquet and CSV batches using metainfo-derived Arrow schemas.
- Run tabular processing in a spawned subprocess for reliable memory reclamation.
- Include `entry_id` and `upload_id` as leading tabular columns.
- Add configurable archive timeouts, entry limits, and Arrow buffer sizing.