### PR TITLE
Move the return outside finally 

### DIFF
--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -182,4 +182,4 @@ class ExportEntriesWorkflow:
                 workflow_duration=round(workflow.time() - starttime, 6),
             )
 
-            return output
+        return output


### PR DESCRIPTION
The workflow can therefore report failure after manifest/archive generation failed.