### PR TITLE
Separate extract entries workflow

### DIFF
--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -33,6 +33,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
             prepare_manifest,
             read_archives_and_write_output_json,
             read_archives_and_write_output_tabular,
+            write_metadata_file,
         )
         from nomad_ml_workflows.actions.export_entries.workflows import (
             ExportEntriesWorkflow,
@@ -50,6 +51,7 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
                 read_archives_and_write_output_tabular,
                 export_dataset_to_upload,
                 cleanup_artifacts,
+                write_metadata_file,
             ],
         )
 

--- a/src/nomad_ml_workflows/actions/export_entries/__init__.py
+++ b/src/nomad_ml_workflows/actions/export_entries/__init__.py
@@ -36,13 +36,14 @@ class ExportEntriesActionEntryPoint(ActionEntryPoint):
         )
         from nomad_ml_workflows.actions.export_entries.workflows import (
             ExportEntriesWorkflow,
+            ExtractEntriesWorkflow,
             ReadArchivesWorkflow,
         )
 
         return Action(
             task_queue=self.task_queue,
             workflow=ExportEntriesWorkflow,
-            child_workflows=[ReadArchivesWorkflow],
+            child_workflows=[ExtractEntriesWorkflow, ReadArchivesWorkflow],
             activities=[
                 prepare_manifest,
                 read_archives_and_write_output_json,

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -123,6 +123,9 @@ def read_archives_and_write_output_json(
     )
     manifest_file_path = artifacts_subdirectory / f'{MANIFEST_FILE_NAME}.json'
     output_file_path = artifacts_subdirectory / f'{DATA_FILE_NAME}.json'
+    temporary_output_file_path = output_file_path.with_stem(
+        f'{output_file_path.stem}.tmp'
+    )
 
     # load manifest
     with open(manifest_file_path, encoding='utf-8') as f:
@@ -132,7 +135,8 @@ def read_archives_and_write_output_json(
     activity_logger = logger.bind(activity_type=info.activity_type)
 
     archives = generate_archives(manifest, data.required, data.user_id, activity_logger)
-    num_entries_exported = write_dicts_to_json(archives, output_file_path)
+    num_entries_exported = write_dicts_to_json(archives, temporary_output_file_path)
+    temporary_output_file_path.replace(output_file_path)
 
     return OutputFile(
         file_path=output_file_path.as_posix(),
@@ -153,6 +157,9 @@ def _read_archives_and_write_output_tabular(
     output_file_path = (
         artifacts_subdirectory / f'{DATA_FILE_NAME}.{data.output_file_format}'
     )
+    temporary_output_file_path = output_file_path.with_stem(
+        f'{output_file_path.stem}.tmp'
+    )
 
     # load manifest
     with open(manifest_file_path, encoding='utf-8') as f:
@@ -165,11 +172,12 @@ def _read_archives_and_write_output_tabular(
     activity_logger.info('Writing table rows to tabular file...')
     num_entries_exported = write_table_rows_to_tabular_file(
         table_rows_file_path,
-        output_file_path,
+        temporary_output_file_path,
         columns_quantity_def,
         max_buffer_bytes=config.max_write_buffer_size_bytes,  # type: ignore
         logger=activity_logger,
     )
+    temporary_output_file_path.replace(output_file_path)
     activity_logger.info(
         f'{num_entries_exported} table rows written to '
         f'"data.{data.output_file_format}" file.'

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -236,8 +236,6 @@ async def export_dataset_to_upload(data: ExportDatasetInput) -> str:
     Activity to export the generated dataset files to the specified upload.
     Creates a ZIP archive if `data.zip_output` is `True`.
 
-    Args:
-        data (ExportDatasetInput): Input data for exporting the dataset to the upload.
     Returns:
         str: Relative path, within the upload raw directory, of the directory
             containing the exported dataset.
@@ -263,12 +261,22 @@ async def export_dataset_to_upload(data: ExportDatasetInput) -> str:
         raise ValueError(
             f'Staging upload with ID {data.upload_id} for user {data.user_id} not found.'
         )
+    exportable_dir_name = unique_filename(data.exportable_dir_name, upload_files)
 
     artifacts_subdirectory = Path(
         action_instance_artifacts_dir(data.export_entries_workflow_id)
     )
-    exportable_filepaths = [Path(source_path) for source_path in data.source_paths]
-    exportable_dir_name = unique_filename(data.exportable_dir_name, upload_files)
+
+    # Discover metadata, manifest, and data files in the artifacts subdirectory
+    export_order = (METADATA_FILE_NAME, MANIFEST_FILE_NAME, DATA_FILE_NAME)
+    files_by_stem = {
+        path.stem: path
+        for path in artifacts_subdirectory.iterdir()
+        if path.is_file() and path.stem in export_order
+    }
+    exportable_filepaths = [
+        files_by_stem[stem] for stem in export_order if stem in files_by_stem
+    ]
 
     # Create a zip file containing all the source paths and the metadata file
     if data.zip_output:

--- a/src/nomad_ml_workflows/actions/export_entries/activities.py
+++ b/src/nomad_ml_workflows/actions/export_entries/activities.py
@@ -20,10 +20,12 @@ from nomad_ml_workflows.actions.export_entries.models import (
     ExportDatasetInput,
     ManifestEntry,
     ManifestFile,
+    MetadataFile,
     OutputFile,
     PrepareManifestInput,
     PrepareManifestOutput,
     ReadArchivesWorkflowInput,
+    WriteMetadataFileInput,
 )
 from nomad_ml_workflows.actions.export_entries.utils import (
     generate_archives,
@@ -207,15 +209,38 @@ def read_archives_and_write_output_tabular(
 
 
 @activity.defn
+async def write_metadata_file(data: WriteMetadataFileInput) -> MetadataFile:
+    """Create a metadata.json file in the artifact subdirectory"""
+    artifact_subdirectory = Path(
+        action_instance_artifacts_dir(data.export_entries_workflow_id)
+    )
+    metadata_file_path = artifact_subdirectory / f'{METADATA_FILE_NAME}.json'
+    metadata_dict = {
+        'note': 'This metadata file contains information about the exported dataset '
+        'and the conditions under which it was generated.',
+        'data': data.metadata.model_dump(),
+        'schema': data.metadata.model_json_schema(),
+    }
+    with open(metadata_file_path, 'w', encoding='utf-8') as metafile:
+        json.dump(metadata_dict, metafile, indent=2)
+
+    return MetadataFile(
+        file_path=metadata_file_path.as_posix(),
+        file_size=metadata_file_path.stat().st_size,
+    )
+
+
+@activity.defn
 async def export_dataset_to_upload(data: ExportDatasetInput) -> str:
     """
-    Activity to export the generated dataset files as a zip file to the specified
-    upload. A metadata file is also included in the zip.
+    Activity to export the generated dataset files to the specified upload.
+    Creates a ZIP archive if `data.zip_output` is `True`.
 
     Args:
         data (ExportDatasetInput): Input data for exporting the dataset to the upload.
     Returns:
-        str: Path to the saved zip file in the upload.
+        str: Relative path, within the upload raw directory, of the directory
+            containing the exported dataset.
     """
 
     def unique_filename(filename: str, upload_files: StagingUploadFiles) -> str:
@@ -242,23 +267,7 @@ async def export_dataset_to_upload(data: ExportDatasetInput) -> str:
     artifacts_subdirectory = Path(
         action_instance_artifacts_dir(data.export_entries_workflow_id)
     )
-    # Create a metadata.json file in the artifact subdirectory
-    metadata_dict = {
-        'note': 'This metadata file contains information about the exported dataset '
-        'and the conditions under which it was generated.',
-        'data': data.metadata.model_dump(),
-        'schema': data.metadata.model_json_schema(),
-    }
-    metadata_path = artifacts_subdirectory / f'{METADATA_FILE_NAME}.json'
-    with open(metadata_path, 'w', encoding='utf-8') as metafile:
-        json.dump(metadata_dict, metafile, indent=4)
-
-    exportable_filepaths = [metadata_path]
-    if data.source_paths:
-        exportable_filepaths.extend(
-            Path(source_path) for source_path in data.source_paths
-        )
-
+    exportable_filepaths = [Path(source_path) for source_path in data.source_paths]
     exportable_dir_name = unique_filename(data.exportable_dir_name, upload_files)
 
     # Create a zip file containing all the source paths and the metadata file

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -449,9 +449,6 @@ class ExportDatasetInput(BaseModel):
         description='Name of the directory containing the dataset that will be '
         'exported.',
     )
-    source_paths: list[str] = Field(
-        ..., description='Paths to the source files of the dataset.'
-    )
 
 
 class CleanupArtifactsInput(BaseModel):

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -415,6 +415,21 @@ class ExportDatasetMetadata(BaseModel):
     )
 
 
+class WriteMetadataFileInput(BaseModel):
+    export_entries_workflow_id: str = Field(
+        ...,
+        description='ID of the export entries workflow.',
+    )
+    metadata: ExportDatasetMetadata = Field(
+        ..., description='Metadata to be written to the metadata file.'
+    )
+
+
+class MetadataFile(BaseModel):
+    file_path: str = Field(..., description='Path to the metadata file.')
+    file_size: int = Field(..., description='Size of the metadata file in bytes.')
+
+
 class ExportDatasetInput(BaseModel):
     export_entries_workflow_id: str = Field(
         ..., description='ID of the export entries workflow.'
@@ -436,9 +451,6 @@ class ExportDatasetInput(BaseModel):
     )
     source_paths: list[str] = Field(
         ..., description='Paths to the source files of the dataset.'
-    )
-    metadata: ExportDatasetMetadata = Field(
-        ..., description='Metadata associated with the exported dataset.'
     )
 
 

--- a/src/nomad_ml_workflows/actions/export_entries/models.py
+++ b/src/nomad_ml_workflows/actions/export_entries/models.py
@@ -210,6 +210,25 @@ class CreateArtifactSubdirectoryInput(BaseModel):
     subdir_name: str = Field(..., description='Name of the subdirectory to be created.')
 
 
+class ExtractEntriesWorkflowInput(BaseModel):
+    export_entries_workflow_id: str = Field(
+        ..., description='ID of the export entries workflow.'
+    )
+    user_input: ExportEntriesUserInput = Field(
+        ..., description='Original user input for the export entries workflow.'
+    )
+
+
+class ExtractEntriesWorkflowOutput(BaseModel):
+    metadata_file_path: str = Field(
+        '', description='Path to the generated metadata file.'
+    )
+    data_file_path: str = Field('', description='Path to the generated data file.')
+    manifest_file_path: str = Field(
+        '', description='Path to the generated manifest file.'
+    )
+
+
 class NormalizedSearchSettings(BaseModel):
     user_id: str = Field(..., description='User ID performing the search.')
     owner: OwnerLiteral = Field(..., description='Owner of the entries to be searched.')

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -161,6 +161,7 @@ class ExportEntriesWorkflow:
             ) from e
 
         finally:
+            # Always export artifacts once extraction workflow is triggered
             exported_dir_path = await workflow.execute_activity(
                 export_dataset_to_upload,
                 export_dataset_input,
@@ -168,18 +169,17 @@ class ExportEntriesWorkflow:
                 retry_policy=retry_policy,
             )
 
-            await workflow.execute_activity(
-                cleanup_artifacts,
-                CleanupArtifactsInput(
-                    export_entries_workflow_id=workflow.info().workflow_id
-                ),
-                start_to_close_timeout=timedelta(hours=2),
-                retry_policy=retry_policy,
-            )
+        # Cleanup artifacts only if extraction workflow succeeded
+        await workflow.execute_activity(
+            cleanup_artifacts,
+            CleanupArtifactsInput(
+                export_entries_workflow_id=workflow.info().workflow_id
+            ),
+            start_to_close_timeout=timedelta(hours=2),
+            retry_policy=retry_policy,
+        )
 
-            output = ExportEntriesOutput(
-                exported_dir_path=exported_dir_path,
-                workflow_duration=round(workflow.time() - starttime, 6),
-            )
-
-        return output
+        return ExportEntriesOutput(
+            exported_dir_path=exported_dir_path,
+            workflow_duration=round(workflow.time() - starttime, 6),
+        )

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -139,6 +139,7 @@ class ExtractEntriesWorkflow:
                     export_entries_workflow_id=data.export_entries_workflow_id,
                     metadata=metadata,
                 ),
+                start_to_close_timeout=timedelta(hours=2),
                 retry_policy=retry_policy,
             )
             workflow_output.metadata_file_path = metadata_file.file_path

--- a/src/nomad_ml_workflows/actions/export_entries/workflows.py
+++ b/src/nomad_ml_workflows/actions/export_entries/workflows.py
@@ -14,6 +14,7 @@ with workflow.unsafe.imports_passed_through():
         prepare_manifest,
         read_archives_and_write_output_json,
         read_archives_and_write_output_tabular,
+        write_metadata_file,
     )
     from nomad_ml_workflows.actions.export_entries.models import (
         CleanupArtifactsInput,
@@ -21,10 +22,13 @@ with workflow.unsafe.imports_passed_through():
         ExportDatasetMetadata,
         ExportEntriesOutput,
         ExportEntriesUserInput,
+        ExtractEntriesWorkflowInput,
+        ExtractEntriesWorkflowOutput,
         NormalizedSearchSettings,
         OutputFile,
         PrepareManifestInput,
         ReadArchivesWorkflowInput,
+        WriteMetadataFileInput,
     )
 
 config = nomad_config.get_plugin_entry_point(
@@ -59,112 +63,127 @@ class ReadArchivesWorkflow:
 
 
 @workflow.defn
-class ExportEntriesWorkflow:
+class ExtractEntriesWorkflow:
     @workflow.run
-    async def run(self, data: ExportEntriesUserInput) -> ExportEntriesOutput:
+    async def run(
+        self, data: ExtractEntriesWorkflowInput
+    ) -> ExtractEntriesWorkflowOutput:
         """
-        Workflow to search entries and export them into a datafile in the specified
-        upload.
-
-        All search pages are fetched in parallel using child workflows. A lightweight
-        cursor-collection activity first walks the pagination to determine the
-        page_after_value for every page, then one SearchPageWorkflow child workflow
-        is launched per page and all are awaited concurrently.
-
-        Args:
-            data (ExportEntriesUserInput): Input data for the export entries workflow.
-        Returns:
-            str: Path to the saved dataset in the upload's `raw` folder.
+        Find matching entries and write their archives to action artifact subdirectory.
         """
-        starttime = workflow.time()
         retry_policy = RetryPolicy(maximum_attempts=1)
-        export_dataset_input = ExportDatasetInput(
-            export_entries_workflow_id=workflow.info().workflow_id,
-            user_id=data.user_id,
-            upload_id=data.upload_id,
-            exportable_dir_name=(
-                f'export_entries_{workflow.info().start_time.isoformat()}'
-            ),
-            zip_output=data.export_settings.create_zip_archive,
-            source_paths=[],
-            metadata=ExportDatasetMetadata(
-                user_input=data,
-                nomad_deployment_api_host=nomad_config.services.api_host,
-                nomad_version=nomad_config.meta.version,
-                nomad_ml_workflows_version=nomad_ml_workflows_version,
-            ),  # type: ignore
-        )
+        user_input = data.user_input
+        metadata = ExportDatasetMetadata(
+            user_input=user_input,
+            nomad_deployment_api_host=nomad_config.services.api_host,
+            nomad_version=nomad_config.meta.version,
+            nomad_ml_workflows_version=nomad_ml_workflows_version,
+        )  # type: ignore
+        workflow_output = ExtractEntriesWorkflowOutput()  # type: ignore
 
         try:
-            search_settings = NormalizedSearchSettings.from_user_input(data)
+            search_settings = NormalizedSearchSettings.from_user_input(user_input)
 
             manifest_output = await workflow.execute_activity(
                 prepare_manifest,
                 PrepareManifestInput(
-                    export_entries_workflow_id=workflow.info().workflow_id,
+                    export_entries_workflow_id=data.export_entries_workflow_id,
                     user_id=search_settings.user_id,
                     owner=search_settings.owner,
                     query=search_settings.query,
-                    num_entries_user_limit=search_settings.num_entries_user_limit,  # type: ignore
+                    num_entries_user_limit=search_settings.num_entries_user_limit,
                 ),
                 start_to_close_timeout=timedelta(hours=2),
                 retry_policy=retry_policy,
             )
+            workflow_output.manifest_file_path = manifest_output.manifest_file.file_path
 
-            export_dataset_input.metadata.num_entries_available = (
-                manifest_output.num_entries_available
-            )
-            export_dataset_input.metadata.num_entries_selected = (
-                manifest_output.num_entries_selected
-            )
-            export_dataset_input.metadata.search_start_time = (
-                manifest_output.search_start_time
-            )
-            export_dataset_input.metadata.search_end_time = (
-                manifest_output.search_end_time
-            )
-            export_dataset_input.metadata.reached_max_entries_limit = (
+            metadata.num_entries_available = manifest_output.num_entries_available
+            metadata.num_entries_selected = manifest_output.num_entries_selected
+            metadata.reached_max_entries_limit = (
                 manifest_output.reached_max_entries_limit
             )
-            export_dataset_input.source_paths = [
-                manifest_output.manifest_file.file_path
-            ]
+            metadata.search_start_time = manifest_output.search_start_time
+            metadata.search_end_time = manifest_output.search_end_time
 
             if manifest_output.num_entries_selected > 0:
                 output_file: OutputFile = await workflow.execute_child_workflow(
                     ReadArchivesWorkflow.run,
                     ReadArchivesWorkflowInput(
-                        export_entries_workflow_id=workflow.info().workflow_id,
-                        user_id=data.user_id,
-                        output_file_format=data.export_settings.file_format,
+                        export_entries_workflow_id=data.export_entries_workflow_id,
+                        user_id=user_input.user_id,
+                        output_file_format=user_input.export_settings.file_format,
                         required=search_settings.required,
                     ),
                     id=f'{workflow.info().workflow_id}-read-archives-and-write-file',
                     parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
                     retry_policy=retry_policy,
                 )
-                export_dataset_input.metadata.num_entries_exported = (
-                    output_file.num_entries_exported
-                )
-                export_dataset_input.source_paths = [
-                    manifest_output.manifest_file.file_path,
-                    output_file.file_path,
-                ]
+                metadata.num_entries_exported = output_file.num_entries_exported
+                workflow_output.data_file_path = output_file.file_path
 
         except Exception as e:
-            # Capture error info to include in metadata
+            # Add error info to metadata and re-raise
             import traceback
 
-            export_dataset_input.metadata.error_info = traceback.format_exc()
+            metadata.error_info = traceback.format_exc()
+
             raise ApplicationError(
-                'Encountered an error during export entries workflow.',
+                'Encountered an error during reading archives and writing data file.',
             ) from e
 
+        finally:
+            metadata_file = await workflow.execute_activity(
+                write_metadata_file,
+                WriteMetadataFileInput(
+                    export_entries_workflow_id=data.export_entries_workflow_id,
+                    metadata=metadata,
+                ),
+                retry_policy=retry_policy,
+            )
+            workflow_output.metadata_file_path = metadata_file.file_path
+
+        return workflow_output
+
+
+@workflow.defn
+class ExportEntriesWorkflow:
+    @workflow.run
+    async def run(self, data: ExportEntriesUserInput) -> ExportEntriesOutput:
+        """
+        Extract matching entries and export the generated files to an upload.
+        """
+        starttime = workflow.time()
+        retry_policy = RetryPolicy(maximum_attempts=1)
+
+        try:
+            await workflow.execute_child_workflow(
+                ExtractEntriesWorkflow.run,
+                ExtractEntriesWorkflowInput(
+                    export_entries_workflow_id=workflow.info().workflow_id,
+                    user_input=data,
+                ),
+                id=f'{workflow.info().workflow_id}-extract-entries',
+                parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
+                retry_policy=retry_policy,
+            )
+        except Exception as e:
+            raise ApplicationError(
+                'Encountered an error during extract entries workflow.',
+            ) from e
         finally:
             # Always export artifacts once extraction workflow is triggered
             exported_dir_path = await workflow.execute_activity(
                 export_dataset_to_upload,
-                export_dataset_input,
+                ExportDatasetInput(
+                    export_entries_workflow_id=workflow.info().workflow_id,
+                    user_id=data.user_id,
+                    upload_id=data.upload_id,
+                    exportable_dir_name=(
+                        f'export_entries_{workflow.info().start_time.isoformat()}'
+                    ),
+                    zip_output=data.export_settings.create_zip_archive,
+                ),
                 start_to_close_timeout=timedelta(hours=2),
                 retry_policy=retry_policy,
             )


### PR DESCRIPTION
Separates out the artifact creation from moving them to the upload. For this, creates a new child workflow "ExtractEntriesWorflow" and also makes the following changes:

- Takes out metadata file writing from `export_dataset_to_upload` activity into a separate activity
- Allows discovery of exportable files in `export_dataset_to_upload`, rather than relying on exportable paths as input
- Prevents clean up of artifacts if the extract entries workflow fails