### PR TITLE
Add `cpu-action` deps to `dev` deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ maintainers = [
 license = { file = "LICENSE" }
 dependencies = [
     "nomad-lab>=1.4.3",
-    "json-stream",
     "pydantic",
     "temporalio",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ Repository = "https://github.com/FAIRmat-NFDI/nomad-ml-workflows"
 [project.optional-dependencies]
 dev = [
     "nomad-lab[infrastructure]>=1.4.3",
+    "nomad_ml_workflows[cpu-action]",
     "ruff",
     "pytest",
     "structlog",


### PR DESCRIPTION
As there are tests for utils.py that uses pyarrow, we should have `cpu-action` deps in the `dev` deps